### PR TITLE
Transparent proxy implementation in Project VPC. 

### DIFF
--- a/reference-architecture/aws-ansible/cip-on-aws.py
+++ b/reference-architecture/aws-ansible/cip-on-aws.py
@@ -31,6 +31,8 @@ import sys
               show_default=True)
 @click.option('--tech-nb-subnets', default='2', help='Number of Tech subnets (1 per region)',
               show_default=True)
+@click.option('--project-nb-subnets', default='3', help='Number of private subnets for projects (1 per region)',
+              show_default=True)
 @click.option('--project-ocp-nb-subnets', default='3', help='Number of private subnets for OCP (1 per region)',
               show_default=True)
 @click.option('--keypair', help='EC2 keypair name',
@@ -123,6 +125,7 @@ def launch_oil_env(task=None,
                    ciap_nb_subnets=None,
                    admin_nb_subnets=None,
                    tech_nb_subnets=None,
+                   project_nb_subnets=None,
                    project_ocp_nb_subnets=None,
                    keypair=None,
                    create_key=None,
@@ -217,6 +220,7 @@ def launch_oil_env(task=None,
   ciap_nb_subnets = int(ciap_nb_subnets)
   admin_nb_subnets = int(admin_nb_subnets)
   tech_nb_subnets = int(tech_nb_subnets)
+  project_nb_subnets = int(project_nb_subnets)
   project_ocp_nb_subnets = int(project_ocp_nb_subnets)
 
   # Create ssh key pair in AWS if none is specified
@@ -255,6 +259,7 @@ def launch_oil_env(task=None,
   click.echo('\tciap_nb_subnets: %s' % ciap_nb_subnets)
   click.echo('\tadmin_nb_subnets: %s' % admin_nb_subnets)
   click.echo('\ttech_nb_subnets: %s' % tech_nb_subnets)
+  click.echo('\tproject_nb_subnets: %s' % project_nb_subnets)
   click.echo('\tproject_ocp_nb_subnets: %s' % project_ocp_nb_subnets)
   click.echo('\tkeypair: %s' % keypair)
   click.echo('\tcreate_key: %s' % create_key)
@@ -323,6 +328,7 @@ def launch_oil_env(task=None,
     ciap_nb_subnets=%s \
     admin_nb_subnets=%s \
     tech_nb_subnets=%s \
+    project_nb_subnets=%s \
     project_ocp_nb_subnets=%s \
     keypair=%s \
     create_key=%s \
@@ -363,6 +369,7 @@ def launch_oil_env(task=None,
 														int(ciap_nb_subnets),
 														int(admin_nb_subnets),
 														int(tech_nb_subnets),
+														int(project_nb_subnets),
 														int(project_ocp_nb_subnets),
 														keypair,
 														create_key,

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/bootstrap/common/bootstrap.sh.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/bootstrap/common/bootstrap.sh.j2
@@ -4,7 +4,7 @@
 # $1: CloudFormation stack name
 # $2: CloudWatch Logs log group
 # $3: S3 Bucket location
-# 
+#
 
 stackname="$1"
 loggroup="$2"
@@ -60,6 +60,8 @@ case $NETFUNC in
 		HNPREF=waf;;
 	"nat")
 		HNPREF=nat;;
+	"tp")
+		HNPREF=tp;;
 	"vpn")
 		HNPREF=vpn;;
 	"bastion")

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/bootstrap/tp/bootstrap-tp.sh.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/bootstrap/tp/bootstrap-tp.sh.j2
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Description: this script creates required transparent squid proxy configuration
+#
+# Arguments
+# $1: CloudFormation stack name
+# $2: CloudWatch Logs log group
+# $3: S3 Bucket containing squid package
+#
+
+### Parameters
+
+stackname="$1"
+loggroup="$2"
+s3loc="$3"
+
+# HTTP_PROXY
+PROXY_NO_PROTO=${HTTP_PROXY#*//}
+HTTP_PROXY_HOST=${PROXY_NO_PROTO%:*}
+HTTP_PROXY_PORT=${PROXY_NO_PROTO#*:}
+
+
+### Functions
+
+# Checking parameters
+check_parameters() {
+  if [ -z "$stackname" ] || [ -z "$loggroup" ] || [ -z "$s3loc" ]; then
+    echo "Missing arguments"
+    exit 1
+  fi
+  if [ -z "$HTTP_PROXY" ]; then
+    echo "Missing HTTP_PROXY environment variable"
+    exit 1
+  fi
+}
+
+
+# Create self-signed SSL certificate for squid.
+# The certificate is required only for squid to startup but will not be used
+# since we will run squid as a layer 4 proxy
+generate_squid_cert() {
+  mkdir -p /etc/squid/ssl_cert
+  cd /etc/squid/ssl_cert
+  openssl req -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -extensions v3_ca -keyout myCA.pem -out myCA.pem -subj "/C=FR/ST=Paris/L=Paris/O=Société Générale/OU=RESG-GTS/CN=oip-transparent-squid.aws"
+}
+
+# Function to generate squid configuration to act as a transparent proxy
+generate_squid_config() {
+  cat > /etc/squid/squid.conf<<EOT
+  # ACL definitions
+  acl SSL_ports port 443
+  acl Safe_ports port 80          # http
+  acl Safe_ports port 21          # ftp
+  acl Safe_ports port 443         # https
+  acl Safe_ports port 70          # gopher
+  acl Safe_ports port 210         # wais
+  acl Safe_ports port 1025-65535  # unregistered ports
+  acl Safe_ports port 280         # http-mgmt
+  acl Safe_ports port 488         # gss-http
+  acl Safe_ports port 591         # filemaker
+  acl Safe_ports port 777         # multiling http
+  acl CONNECT method CONNECT
+
+  acl srv-aws src 10.0.0.0/8
+
+  http_access deny !Safe_ports
+  http_access deny CONNECT !SSL_ports
+  http_access allow localhost manager
+  http_access deny manager
+  http_access allow localhost
+  #http_access allow srv-aws s3
+  #http_access allow srv-aws virtual_host_urls
+  #http_access allow srv-aws path_urls
+  http_access allow srv-aws
+  http_access allow all
+
+  cache_effective_group squid
+  cache_effective_user squid
+
+  http_port 3128 transparent
+  #https_port 3130 intercept ssl-bump cert=/etc/squid/ssl_cert/myCA.pem generate-host-certificates=on dynamic_cert_mem_cache_size=4MB  options=NO_SSLv2,NO_SSLv3,NO_TLSv1,NO_TLSv1_1,NO_TICKET cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+  https_port 3130 intercept ssl-bump cert=/etc/squid/ssl_cert/myCA.pem
+
+  ssl_bump splice all
+
+  cache_peer $HTTP_PROXY_HOST parent $HTTP_PROXY_PORT 0 no-query default
+
+  coredump_dir /var/spool/squid
+
+  refresh_pattern ^ftp:           1440    20%     10080
+  refresh_pattern ^gopher:        1440    0%      1440
+  refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+  refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+  refresh_pattern .               0       20%     4320
+
+  never_direct allow srv-aws
+  never_direct allow localhost
+
+  dns_v4_first off
+
+  via on
+
+  httpd_suppress_version_string off
+
+  forwarded_for on
+
+  access_log daemon:/var/log/squid/access.log combined
+  logformat combined %>a %ui %un [%tl] "%rm %ru HTTP/%rv" %Hs %<st "%{Referer}>h" "%{User-Agent}>h" %Ss:%Sh
+
+  netdb_filename stdio:/var/log/squid/netdb.state
+
+  pinger_enable on
+
+  # Increasing the number of file descriptors to solve cache errors
+  max_filedescriptors 65535
+EOT
+}
+
+install_and_run_squid() {
+  echo "-> Installing squid"
+  yum -y install squid
+
+  echo "-> Generating the Squid SSL Certificate"
+  generate_squid_cert
+
+  echo "-> Generating the Squid configuration"
+  generate_squid_config
+
+  if $(type systemctl >/dev/null 2>&1); then
+    echo "-> Enabling the Squid service"
+    systemctl enable squid
+    echo "-> Starting the Squid service"
+    systemctl start squid
+  else
+    echo "-> Enabling the Squid service"
+    chkconfig squid on
+    echo "-> Starting the Squid service"
+    service squid start
+  fi
+
+  #echo "-> Running Squid service as docker container"
+  #docker run --name squid -d --restart=always \
+  #  --publish 3128:3128 \
+  #  --publish 3130:3130 \
+  #  --volume /etc/squid/squid.conf:/etc/squid/squid.conf \
+  #  --volume /etc/squid/ssl_cert/myCA.pem:/etc/squid/ssl_cert/myCA.pem \
+  #  --volume /srv/docker/squid/cache:/var/spool/squid \
+  #  sameersbn/squid:3.5.27-1
+
+}
+
+set_as_router() {
+  echo "-> Adding IPTables rules to forward port 80 and 443 to the transparent Squid instance"
+  iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 3128
+  iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 3130
+
+  II_URI="http://169.254.169.254/latest/dynamic/instance-identity/document"
+  # Set AZ of NAT instance
+  REGION=`curl --retry 3 --retry-delay 0 --silent --fail $II_URI | grep region | awk -F\" '{print $4}'`
+  INSTANCE_ID=`curl --retry 3 --retry-delay 0 --silent --fail $II_URI | grep instanceId | awk -F\" '{print $4}'`
+  VPC_ID=`aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[*].Instances[*].VpcId' --region $REGION --output text`
+  #TODO: Since the current automation creates a secondary route table, we need to pick a non 'main' route.
+  #      it works since there is only one such route table. Automation should be changed to use default route tables instead of specific one.
+  #MAIN_RT=`aws ec2 describe-route-tables --query 'RouteTables[*].RouteTableId' --filters Name=vpc-id,Values=$VPC_ID Name=association.main,Values=true --region $REGION --output text`
+  MAIN_RT=`aws ec2 describe-route-tables --query 'RouteTables[*].RouteTableId' --filters Name=vpc-id,Values=$VPC_ID Name=association.main,Values=false --region $REGION --output text`
+
+  # Printing some debuging information...
+  cat <<EOT
+  Transparent SQUID proxy - Initializing
+  - Region: $REGION
+  - VPC ID: $VPC_ID
+  - Instance ID: $INSTANCE_ID
+  - Route table: $MAIN_RT
+EOT
+
+  echo "-> Allowing instance to route traffic by disabling Src/Dest Check"
+  aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --no-source-dest-check --region $REGION
+
+
+  echo "-> Creating route default route pointing at the current instance"
+  aws ec2 create-route --route-table-id $MAIN_RT --destination-cidr-block 0.0.0.0/0 --instance-id $INSTANCE_ID --region $REGION --output text
+  if [ $? -ne 0 ] ; then
+    echo  "-> Default route already exists, replacing it with one pointing at the current instance"
+    aws ec2 replace-route --route-table-id $MAIN_RT --destination-cidr-block 0.0.0.0/0 --instance-id $INSTANCE_ID --region $REGION --output text
+  fi
+}
+
+
+
+### Main logic!
+
+check_parameters
+get_context
+install_and_run_squid
+set_as_router

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network-functions.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network-functions.yaml.j2
@@ -5,6 +5,7 @@ Description: >
     WAF: CIAP - Hosting - Web Application Firewall instances
     NAT: CIAP - Browsing - Web Browsing NAT instances
     VPN: CIAP - VPN Concentrators - remote ssh/rdp access to Admin VPC
+    TP: Project - Transparent HTTP/HTTPS internet proxy
 
   **WARNING** This template creates AWS resources. You will be billed for the AWS
   resources used if you create a stack from this template. QS(0027)
@@ -233,6 +234,11 @@ Parameters:
     Description: Admin subnet ID
     Type: String
 {% endfor %}
+{% for idx in range(1, project_nb_subnets|int + 1) %}
+  ProjectSubNet{{ idx }}ID:
+    Description: Project default subnet ID
+    Type: String
+{% endfor %}
   WAFUserData:
     Description: WAF instances user data
     Type: String
@@ -294,6 +300,10 @@ Parameters:
     Default: true
     Description: Deploy NAT resources or not
     Type: String
+  DeployTPResources:
+    Default: true
+    Description: Deploy TP resources or not
+    Type: String
   DeployVPNResources:
     Default: true
     Description: Deploy VPN resources or not
@@ -314,10 +324,11 @@ Parameters:
     Default: 3130
     Description: Network port the Squid Instances will be listening to in transparent mode for HTTPS traffic
     Type: String
-  SquidDist:
-    Default: zip
-    Description: Squid distribution to use from 'zip' or 'os'
-    Type: String
+# Reached max parameters, need to remove this one
+#  SquidDist:
+#    Default: zip
+#    Description: Squid distribution to use from 'zip' or 'os'
+#    Type: String
   VPNPort:
     Default: 22
     Description: Network port the VPN Instances will be listening to
@@ -338,12 +349,13 @@ Parameters:
     Type: String
     Description: Enter the S3 Bucket name used to store logs in the form of
       bucket-name/prefix [or bucket-name in the case of root folder]
-  SquidProxyProtocol:
-    Type: String
-    Description: Does the Squid version supports Proxy Protocol. Requires Squid
-      version >3.5
-    AllowedValues: [true, false]
-    Default: true
+# Reached max parameters, need to remove this one
+#  SquidProxyProtocol:
+#    Type: String
+#    Description: Does the Squid version supports Proxy Protocol. Requires Squid
+#      version >3.5
+#    AllowedValues: [true, false]
+#    Default: true
 
 
 
@@ -353,6 +365,7 @@ Mappings:
     eu-west-1:
       AWSWAFHVM: {{ netfunc_vars['AWSWAFHVM'] }}
       AWSNATHVM: {{ netfunc_vars['AWSNATHVM'] }}
+      AWSTPHVM: {{ netfunc_vars['AWSTPHVM'] }}
       AWSVPNHVM: {{ netfunc_vars['AWSVPNHVM'] }}
       AWSBastionHVM: {{ netfunc_vars['AWSBastionHVM'] }}
 
@@ -364,6 +377,7 @@ Conditions:
   4AZCondition: !Equals [!Ref NumberOfAZs, 4]
   WAFInstanceCondition: !Equals [!Ref DeployWAFResources, true]
   NATInstanceCondition: !Equals [!Ref DeployNATResources, true]
+  TPInstanceCondition: !Equals [!Ref DeployTPResources, true]
   VPNInstanceCondition: !Equals [!Ref DeployVPNResources, true]
   BastionInstanceCondition: !Equals [!Ref DeployVPNResources, true]
   WAFInstance&1AZCondition: !And [{Condition: WAFInstanceCondition}, {Condition: 1AZCondition}]
@@ -374,6 +388,10 @@ Conditions:
   NATInstance&2AZCondition: !And [{Condition: NATInstanceCondition}, {Condition: 2AZCondition}]
   NATInstance&3AZCondition: !And [{Condition: NATInstanceCondition}, {Condition: 3AZCondition}]
   NATInstance&4AZCondition: !And [{Condition: NATInstanceCondition}, {Condition: 4AZCondition}]
+  TPInstance&1AZCondition: !And [{Condition: TPInstanceCondition}, {Condition: 1AZCondition}]
+  TPInstance&2AZCondition: !And [{Condition: TPInstanceCondition}, {Condition: 2AZCondition}]
+  TPInstance&3AZCondition: !And [{Condition: TPInstanceCondition}, {Condition: 3AZCondition}]
+  TPInstance&4AZCondition: !And [{Condition: TPInstanceCondition}, {Condition: 4AZCondition}]
   VPNInstance&1AZCondition: !And [{Condition: VPNInstanceCondition}, {Condition: 1AZCondition}]
   VPNInstance&2AZCondition: !And [{Condition: VPNInstanceCondition}, {Condition: 2AZCondition}]
   VPNInstance&3AZCondition: !And [{Condition: VPNInstanceCondition}, {Condition: 3AZCondition}]
@@ -383,7 +401,8 @@ Conditions:
   BastionInstance&3AZCondition: !And [{Condition: BastionInstanceCondition}, {Condition: 3AZCondition}]
   BastionInstance&4AZCondition: !And [{Condition: BastionInstanceCondition}, {Condition: 4AZCondition}]
   NVirginiaRegionCondition: !Equals [!Ref 'AWS::Region', us-east-1]
-  SupportProxyProtocol: !Equals [!Ref 'SquidProxyProtocol', true]
+#  SupportProxyProtocol: !Equals [!Ref 'SquidProxyProtocol', true]
+  SupportProxyProtocol: !Equals [true, true]
   S3VPCEndpointCondition: !Not [!Or [
         !Equals [!Ref 'AWS::Region', us-gov-west-1], !Equals [!Ref 'AWS::Region',
           cn-north-1]]]
@@ -461,7 +480,7 @@ Resources:
           NFSCRIPT="bootstrap-${!NETFUNC}.sh"
           #aws s3 cp s3://${S3Location}/bootstrap/$NETFUNC/$NFSCRIPT ./
           #chmod +x ./$NFSCRIPT
-          #./$NFSCRIPT ${AWS::StackName} ${NATCloudWatchLogsGroup} ${S3Location } 2>&1 | tee /var/log/oil-bootstrap-${!NETFUNC}
+          #./$NFSCRIPT ${AWS::StackName} ${WAFCloudWatchLogsGroup} ${S3Location } 2>&1 | tee /var/log/oil-bootstrap-${!NETFUNC}
 
           aws s3 cp --recursive s3://${S3Location}/bootstrap/waf/etc/ /etc/
           docker run -d  \
@@ -629,7 +648,7 @@ Resources:
           NFSCRIPT="bootstrap-${!NETFUNC}.sh"
           aws s3 cp s3://${S3Location}/bootstrap/$NETFUNC/$NFSCRIPT ./
           chmod +x ./$NFSCRIPT
-          ./$NFSCRIPT ${SquidDist} ${SquidPort} ${AWS::StackName} ${NATCloudWatchLogsGroup} ${S3Location } 2>&1 | tee /var/log/oil-bootstrap-${!NETFUNC}
+          ./$NFSCRIPT zip ${SquidPort} ${AWS::StackName} ${NATCloudWatchLogsGroup} ${S3Location } 2>&1 | tee /var/log/oil-bootstrap-${!NETFUNC}
           echo "MY-CLOUD-INIT-SCRIPT: Done!"
 
   NATElasticLoadBalancer:
@@ -1041,6 +1060,247 @@ Resources:
 
   ### VPC Project
 
+  ### BEGIN Transparent proxy
+  # Using some NAT* variables since we reached the maximum number of
+  # CloudFormation parameters (60 as of writing)
+  TPAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      LaunchConfigurationName: !Ref 'TPAutoScalingLaunchConfiguration'
+      #TargetGroupARNs:
+      #- !Ref TPELBTargetGroup80
+      #- !Ref TPELBTargetGroup443
+      #- !Ref TPELBTargetGroup3128
+      DesiredCapacity: '1'
+      MinSize: '1'
+      MaxSize: '10'
+      VPCZoneIdentifier:
+{% for idx in range(1, project_ocp_nb_subnets|int + 1) %}
+      - !Ref 'ProjectSubNet{{ idx }}ID'
+{% endfor %}
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: '300'
+      Tags:
+      - PropagateAtLaunch: true
+        Key: "Name"
+        Value: "{{ stack_name }}-project-tpinstance"
+      - PropagateAtLaunch: true
+        Key: "Function"
+        Value: "TP"
+
+  TPAutoScalingLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      IamInstanceProfile:
+        Fn::ImportValue:
+          !Sub "{{ stack_name }}-rlp-TPEC2InstanceProfile"
+
+      AssociatePublicIpAddress: false
+      # Using NAT instance type
+      InstanceType: !Ref NATInstanceType
+      KeyName: !Ref KeyPairName
+      SecurityGroups:
+      - Fn::ImportValue:
+          !Sub "{{ stack_name }}-secgrp-TPInstanceSecurityGroupID"
+      ImageId: !FindInMap [AWSAMIRegionMap, !Ref 'AWS::Region', 'AWSTPHVM']
+      InstanceMonitoring: false
+      UserData:
+        Fn::Base64: !Sub
+          - |
+            #!/bin/bash
+            echo "MY-CLOUD-INIT-SCRIPT: Start"
+            export NETFUNC=tp
+            export TPCloudWatchLogsGroup="${TPCloudWatchLogsGroup}"
+
+            # Make sure we have internet access thru upstream proxy
+            export http_proxy=http://webproxy.{{private_dns_domain}}:{{squid_port}}
+            export HTTP_PROXY=http://webproxy.{{private_dns_domain}}:{{squid_port}}
+            export https_proxy=http://webproxy.{{private_dns_domain}}:{{squid_port}}
+            export HTTPS_PROXY=http://webproxy.{{private_dns_domain}}:{{squid_port}}
+            export no_proxy="localhost,127.0.0.0/8,169.254.169.254,*.{{private_dns_domain}},*.s3.amazonaws.com"
+            export NO_PROXY="localhost,127.0.0.0/8,169.254.169.254,*.{{private_dns_domain}},*.s3.amazonaws.com"
+
+            CMD='curl -sL -w "%{http_code}" "https://s3.eu-west-1.amazonaws.com/" -o /dev/null --retry 5 --max-time 3'
+            while [ "$(eval $CMD)" != "200" ]; do
+              echo "MY-CLOUD-INIT-SCRIPT: Unable to access upstream proxy, sleeping 5 seconds"
+              sleep 5
+            done
+
+            cd /root
+
+            # Common bootstrap
+            echo "MY-CLOUD-INIT-SCRIPT: Fetching common bootstrap script"
+            aws s3 cp s3://${S3Location}/bootstrap/common/bootstrap.sh ./
+            chmod +x ./bootstrap.sh
+            echo "MY-CLOUD-INIT-SCRIPT: Launching common bootstrap script"
+            ./bootstrap.sh ${AWS::StackName} $TPCloudWatchLogsGroup ${S3Location} 2>&1 | tee /var/log/oil-bootstrap
+
+            # Function-specific bootstrap
+            echo "MY-CLOUD-INIT-SCRIPT: Fetching '$NETFUNC-specific' bootstrap script & launching it"
+            NFSCRIPT="bootstrap-${!NETFUNC}.sh"
+            aws s3 cp s3://${S3Location}/bootstrap/$NETFUNC/$NFSCRIPT ./
+            chmod +x ./$NFSCRIPT
+            ./$NFSCRIPT ${AWS::StackName} $TPCloudWatchLogsGroup ${S3Location} 2>&1 | tee /var/log/oil-bootstrap-${!NETFUNC}
+            echo "MY-CLOUD-INIT-SCRIPT: Done!"
+          - TPCloudWatchLogsGroup:
+              Fn::ImportValue:
+                !Sub "{{ stack_name }}-rlp-TPCloudWatchLogsGroup"
+
+
+#  TPElasticLoadBalancer:
+#    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+#    Properties:
+#      Type: network
+#      IpAddressType: ipv4
+#      LoadBalancerAttributes:
+#        - Key: access_logs.s3.enabled
+#          Value: True
+#        - Key: access_logs.s3.bucket
+#          Value: !Ref S3LogsLocation
+#        - Key: access_logs.s3.prefix
+#          Value: ''
+#        - Key: deletion_protection.enabled
+#          Value: False
+#        - Key: load_balancing.cross_zone.enabled
+#          Value: True
+#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PROJECT-TPELB']]
+#      Scheme: internal
+#      Subnets:
+#{% for idx in range(1, project_nb_subnets|int + 1) %}
+#        - !Ref 'ProjectSubNet{{ idx }}ID'
+#{% endfor %}
+#      Tags:
+#        - Key: StackName
+#          Value: !Ref 'AWS::StackName'
+#
+#  TPELBTargetGroup80:
+#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+#    Properties:
+#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PRJ-TPELBTG80']]
+#      Port: 80
+#      Protocol: TCP
+#      VpcId:
+#        Fn::ImportValue:
+#          !Sub "{{ stack_name }}-net-VPCProjectID"
+#      TargetGroupAttributes:
+#        - Key: deregistration_delay.timeout_seconds
+#          Value: 60
+#      Tags:
+#        - Key: StackName
+#          Value: !Ref 'AWS::StackName'
+#  TPELBTargetGroup443:
+#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+#    Properties:
+#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PRJ-TPELBTG443']]
+#      Port: 443
+#      Protocol: TCP
+#      VpcId:
+#        Fn::ImportValue:
+#          !Sub "{{ stack_name }}-net-VPCProjectID"
+#      TargetGroupAttributes:
+#        - Key: deregistration_delay.timeout_seconds
+#          Value: 60
+#      Tags:
+#        - Key: StackName
+#          Value: !Ref 'AWS::StackName'
+#  TPELBTargetGroup3128:
+#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+#    Properties:
+#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PRJ-TPELBTG3128']]
+#      Port: 3128
+#      Protocol: TCP
+#      VpcId:
+#        Fn::ImportValue:
+#          !Sub "{{ stack_name }}-net-VPCProjectID"
+#      TargetGroupAttributes:
+#        - Key: deregistration_delay.timeout_seconds
+#          Value: 60
+#      Tags:
+#        - Key: StackName
+#          Value: !Ref 'AWS::StackName'
+#
+#  TPELBListener80:
+#    Type: AWS::ElasticLoadBalancingV2::Listener
+#    Properties:
+#      DefaultActions:
+#      - Type: forward
+#        TargetGroupArn: !Ref TPELBTargetGroup80
+#      LoadBalancerArn: !Ref TPElasticLoadBalancer
+#      Port: '80'
+#      Protocol: TCP
+#  TPELBListener443:
+#    Type: AWS::ElasticLoadBalancingV2::Listener
+#    Properties:
+#      DefaultActions:
+#      - Type: forward
+#        TargetGroupArn: !Ref TPELBTargetGroup443
+#      LoadBalancerArn: !Ref TPElasticLoadBalancer
+#      Port: '443'
+#      Protocol: TCP
+#  TPELBListener3128:
+#    Type: AWS::ElasticLoadBalancingV2::Listener
+#    Properties:
+#      DefaultActions:
+#      - Type: forward
+#        TargetGroupArn: !Ref TPELBTargetGroup3128
+#      LoadBalancerArn: !Ref TPElasticLoadBalancer
+#      Port: '3128'
+#      Protocol: TCP
+#
+  TPScaleOutPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref 'TPAutoScalingGroup'
+      Cooldown: '300'
+      ScalingAdjustment: '1'
+
+  TPScaleInPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref 'TPAutoScalingGroup'
+      Cooldown: '300'
+      ScalingAdjustment: '-1'
+
+  TPAlarmScaleOutPolicy:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Scale out if average Squid traffic > 5000 KB/s for 5 minutes
+      MetricName: TotalKbytesPerSecond
+      Namespace: CIAP
+      Statistic: Average
+      Period: '300'
+      EvaluationPeriods: '1'
+      Threshold: '5000'
+      Dimensions:
+      - Name: StackName
+        Value: !Ref 'AWS::StackName'
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !Ref 'TPScaleOutPolicy'
+
+  TPAlarmScaleInPolicy:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Scale in if average Squid traffic < 2000 KB/s for 15 minutes
+      MetricName: TotalKbytesPerSecond
+      Namespace: CIAP
+      Statistic: Average
+      Period: '300'
+      EvaluationPeriods: '3'
+      Threshold: '2000'
+      Dimensions:
+      - Name: StackName
+        Value: !Ref 'AWS::StackName'
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+      - !Ref 'TPScaleInPolicy'
+
+
+  ### END Transparent proxy
+
+
 Outputs:
   BastionELBName:
     Description: Name of Bastion instance ELB
@@ -1054,6 +1314,12 @@ Outputs:
   WAFDNSName:
     Description: DNS Name of WAF proxy ELB
     Value: !GetAtt [WAFElasticLoadBalancer, DNSName]
+#  TPELBName:
+#    Description: Name of Transparent proxy ELB
+#    Value: !Ref 'TPElasticLoadBalancer'
+#  TPDNSName:
+#    Description: DNS Name of Transparent proxy ELB
+#    Value: !GetAtt [TPElasticLoadBalancer, DNSName]
   SquidELBName:
     Description: Name of Squid proxy ELB
     Value: !Ref 'NATElasticLoadBalancer'
@@ -1069,4 +1335,3 @@ Outputs:
   VPNDNSName:
     Description: DNS Name of VPN Concentrator ELB
     Value: !GetAtt [VPNElasticLoadBalancer, DNSName]
-

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network.yaml.j2
@@ -89,6 +89,14 @@ Parameters:
     Default: 10.0.128.0/17
     Description: CIDR block for the Project VPC
     Type: String
+{% for idx in range(1, project_nb_subnets|int + 1) %}
+  ProjectSubNet{{ idx }}CIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.{{ 250 + ( idx - 1 ) }}.0/24
+    Description: CIDR block for Project default subnet {{ idx }} located in Availability Zone {{ idx }}
+    Type: String
+{% endfor %}
   S3BucketPrefix:
     Description: S3 Bucket Prefix
     Type: String
@@ -413,13 +421,13 @@ Resources:
         Statement:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
-          Action: 
+          Action:
             - 's3:CreateBucket'
             - 's3:List*'
             - 's3:Get*'
             - 's3:Put*'
           Effect: Allow
-          Resource: 
+          Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*/*']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data']]
@@ -523,13 +531,13 @@ Resources:
         Statement:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
-          Action: 
+          Action:
             - 's3:CreateBucket'
             - 's3:List*'
             - 's3:Get*'
             - 's3:Put*'
           Effect: Allow
-          Resource: 
+          Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*/*']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data']]
@@ -574,12 +582,42 @@ Resources:
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Project-RouteTable']]
       - Key: Network
         Value: Project
-  ProjectRoute2Ciap:
+{% for idx in range(1, project_nb_subnets|int + 1) %}
+  ProjectSubNet{{ idx }}:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref 'VPCProject'
+      CidrBlock: !Ref 'ProjectSubNet{{ idx }}CIDR'
+      AvailabilityZone:
+        Fn::Select:
+          - {{ idx - 1 }}
+          - Fn::GetAZs: ""
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'Project-subnet-{{ idx }}']]
+      - Key: Network
+        Value: Project
+      - Key: kubernetes.io/cluster/{{stack_name}}
+        Value: owned
+  ProjectSubNet{{ idx }}RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref 'ProjectSubNet{{ idx }}'
+      RouteTableId: !Ref 'ProjectRouteTable'
+{% endfor %}
+  ProjectRoute2Default:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2ProjectPeeringConnection
     Properties:
       RouteTableId: !Ref 'ProjectRouteTable'
       DestinationCidrBlock: 0.0.0.0/0
+      VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
+  ProjectRoute2Ciap:
+    Type: AWS::EC2::Route
+    DependsOn: VPCCiap2ProjectPeeringConnection
+    Properties:
+      RouteTableId: !Ref 'ProjectRouteTable'
+      DestinationCidrBlock: !Ref VPCCiapCIDR
       VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
   ProjectRoute2Admin:
     Type: AWS::EC2::Route
@@ -603,13 +641,13 @@ Resources:
         Statement:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
-          Action: 
+          Action:
             - 's3:CreateBucket'
             - 's3:List*'
             - 's3:Get*'
             - 's3:Put*'
           Effect: Allow
-          Resource: 
+          Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*/*']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data']]
@@ -625,25 +663,25 @@ Resources:
   ### Public zones are created by Ansible because they may need to persist when stack is deleted...
   DNSPrivateZone:
     Type: "AWS::Route53::HostedZone"
-    Properties: 
-      HostedZoneConfig: 
+    Properties:
+      HostedZoneConfig:
         Comment: !Join ['', ['Private DNS Domain Name for stack ', !Ref 'AWS::StackName']]
       Name: !Ref PrivateDNSDomain
-      VPCs: 
-        - 
+      VPCs:
+        -
           VPCId: !Ref 'VPCCiap'
           VPCRegion: !Ref 'AWS::Region'
-        - 
+        -
           VPCId: !Ref 'VPCAdmin'
           VPCRegion: !Ref 'AWS::Region'
-        - 
+        -
           VPCId: !Ref 'VPCTech'
           VPCRegion: !Ref 'AWS::Region'
-        - 
+        -
           VPCId: !Ref 'VPCProject'
           VPCRegion: !Ref 'AWS::Region'
-      HostedZoneTags: 
-        - 
+      HostedZoneTags:
+        -
           Key: "DomainName"
           Value: !Ref PrivateDNSDomain
 
@@ -766,6 +804,18 @@ Outputs:
     Description: Project route table
     Export:
       Name: !Sub '${AWS::StackName}-ProjectRouteTable'
+{% for idx in range(1, project_nb_subnets|int + 1) %}
+  ProjectSubNet{{ idx }}CIDR:
+    Description: Project default ID in Availability Zone {{ idx }}
+    Value: !Ref 'ProjectSubNet{{ idx }}CIDR'
+    Export:
+      Name: !Sub '${AWS::StackName}-ProjectSubNet{{ idx }}CIDR'
+  ProjectSubNet{{ idx }}ID:
+    Description: Project default SubNet ID in Availability Zone {{ idx }}
+    Value: !Ref 'ProjectSubNet{{ idx }}'
+    Export:
+      Name: !Sub '${AWS::StackName}-ProjectSubNet{{ idx }}ID'
+{% endfor %}
   VPCCiapS3VPCEndpointID:
     Value: !Ref 'VPCCiapS3VPCEndpoint'
     Description: CIAP VPC Endpoint for S3

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/roles-logs-profiles.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/roles-logs-profiles.yaml.j2
@@ -28,14 +28,14 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/AdministratorAccess"  
+        - "arn:aws:iam::aws:policy/AdministratorAccess"
       RoleName: "GRP-GTS-COE-ADMIN"
   #Role OS Administrator
   GRPGTSOSADM:
@@ -46,7 +46,7 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
@@ -65,16 +65,16 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/ReadOnlyAccess"  
+        - "arn:aws:iam::aws:policy/ReadOnlyAccess"
       Policies:
-        - 
+        -
           PolicyName: "ATM-GTS-COE-INVENTORY"
           PolicyDocument:
             Version: "2012-10-17"
@@ -83,10 +83,10 @@ Resources:
                 Effect: "Allow"
                 Action: "ec2:DescribeTags"
                 Resource: "*"
-              - 
+              -
                 Effect: "Allow"
                 Action: "cloudwatch:GetMetricStatistics"
-                Resource: "*" 
+                Resource: "*"
       RoleName: "ATM-GTS-COE-INVENTORY"
   #Role DB Administrator
   GRPGTSDBADM:
@@ -97,7 +97,7 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
@@ -116,7 +116,7 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
@@ -135,7 +135,7 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
@@ -153,14 +153,14 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/AdministratorAccess"  
+        - "arn:aws:iam::aws:policy/AdministratorAccess"
       RoleName: "GRP-GTS-COE-SEC-ADMIN"
   #Role Security Auditors
   GRPGTSCOESECAUDIT:
@@ -171,14 +171,14 @@ Resources:
         Statement:
           -
             Effect: "Allow"
-            Principal: 
+            Principal:
               AWS:
                 - !Join [":",  [ "arn:aws:iam:", !Ref pIAMAccount, "root"]]
             Action:
               - "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/SecurityAudit"  
+        - "arn:aws:iam::aws:policy/SecurityAudit"
       RoleName: "GRP-GTS-COE-SEC-AUDIT"
   #COEOSADMIN Policy
   COEOSADMIN:
@@ -723,6 +723,93 @@ Resources:
 
   ### END NAT instance / Squid proxy
 
+  ### BEGIN TP instance / Squid proxy
+
+  TPEC2InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+      - !Ref 'TPEC2Role'
+      Path: /
+
+  TPEC2Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: CloudWatch-PutMetricData
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - cloudwatch:PutMetricData
+            Resource: '*'
+      - PolicyName: CloudWatch-Logs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:PutLogEvents
+            - logs:CreateLogStream
+            - logs:DescribeLogStreams
+            - logs:CreateLogGroup
+            Resource: !Join ['', ['arn:aws:logs:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId',
+                ':log-group:', !Ref 'TPCloudWatchLogsGroup', ':log-stream:*']]
+      - PolicyName: S3-Buckets-Access
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:Get*
+            - s3:List*
+            Resource:
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data/bootstrap/tp/*']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs/tp/*']]
+      - PolicyName: EC2-ListAndModifyInstances
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - ec2:DescribeInstances
+            - ec2:DescribeRouteTables
+            - ec2:ModifyInstanceAttribute
+            Resource: '*'
+      - PolicyName: EC2-CreateRoute
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - ec2:CreateRoute
+            - ec2:ReplaceRoute
+            Resource:
+            - "arn:aws:ec2:{{region}}:{{root_account['account_id']}}:route-table/*"
+            Condition:
+              StringEquals:
+                'ec2:vpc' : "arn:aws:ec2:{{region}}:{{root_account['account_id']}}:vpc/{{ cfnet['stack_outputs']['VPCProjectID'] }}"
+
+  TPCloudWatchLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: '14'
+
+  ### END TP instance / Squid proxy
+
   ### BEGIN VPN Instances
 
   VPNEC2InstanceProfile:
@@ -889,10 +976,30 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-NATEC2InstanceProfile
   NATCloudWatchLogsGroup:
-    Description: CloudWatch Logs Group for WAF Instances
+    Description: CloudWatch Logs Group for NAT Instances
     Value: !Ref NATCloudWatchLogsGroup
     Export:
       Name: !Sub ${AWS::StackName}-NATCloudWatchLogsGroup
+  TPEC2Role:
+    Description: Role for TP Instances
+    Value: !Ref TPEC2Role
+    Export:
+      Name: !Sub ${AWS::StackName}-TPEC2Role
+  TPEC2RoleID:
+    Description: RoleId of TP Instances Role
+    Value: !GetAtt [TPEC2Role, Arn]
+    Export:
+      Name: !Sub ${AWS::StackName}-TPEC2RoleID
+  TPEC2InstanceProfile:
+    Description: Instance Profile for TP Instances
+    Value: !Ref TPEC2InstanceProfile
+    Export:
+      Name: !Sub ${AWS::StackName}-TPEC2InstanceProfile
+  TPCloudWatchLogsGroup:
+    Description: CloudWatch Logs Group for TP Instances
+    Value: !Ref TPCloudWatchLogsGroup
+    Export:
+      Name: !Sub ${AWS::StackName}-TPCloudWatchLogsGroup
   VPNEC2Role:
     Description: Role for VPN Instances
     Value: !Ref VPNEC2Role
@@ -938,4 +1045,3 @@ Outputs:
     Value: !Ref BastionCloudWatchLogsGroup
     Export:
       Name: !Sub ${AWS::StackName}-BastionCloudWatchLogsGroup
-

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/s3-bucket-policy-data.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/s3-bucket-policy-data.json.j2
@@ -75,6 +75,26 @@
        }
      },
      {
+       "Sid": "Allow-access-from-TP-instances",
+       "Effect": "Allow",
+       "Principal": "*",
+       "Action": [
+                   "s3:Get*",
+                   "s3:List*"
+                 ],
+       "Resource": [
+                     "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-data' }}",
+                     "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-data' }}/bootstrap/common",
+                     "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-data' }}/bootstrap/common/*",
+                     "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-data' }}/bootstrap/tp/*"
+                   ],
+       "Condition": {
+         "StringLike": {
+           "aws:userId": "{{ roleid_TPEC2Role['iam_roles'][0]['role_id'] }}:*"
+         }
+       }
+     },
+     {
        "Sid": "Allow-access-from-VPN-instances",
        "Effect": "Allow",
        "Principal": "*",

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/s3-bucket-policy-logs.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/s3-bucket-policy-logs.json.j2
@@ -13,8 +13,8 @@
        "Condition": {
          "StringLike": {
            "aws:userId": [
-		   "{{ root_account['iam_user_id'] }}",
-		   "{{ root_account['account_id'] }}"
+		            "{{ root_account['iam_user_id'] }}",
+		            "{{ root_account['account_id'] }}"
                ]
          }
        }
@@ -114,6 +114,25 @@
        },
        "Action": "s3:PutObject*",
        "Resource": "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-logs' }}/AWSLogs/{{ root_account['account_id'] }}/*"
-     }
+     },
+     {
+      "Sid": "AWSLogDeliveryWrite",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [ "delivery.logs.amazonaws.com" ]
+      },
+      "Action": [ "s3:PutObject" ],
+      "Resource": "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-logs' }}/AWSLogs/{{ root_account['account_id'] }}/*",
+      "Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}
+    },
+    {
+      "Sid": "AWSLogDeliveryAclCheck",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [ "delivery.logs.amazonaws.com" ]
+      },
+      "Action": [ "s3:GetBucketAcl" ],
+      "Resource": "arn:aws:s3:::{{ s3_bucket_prefix | lower + '-logs' }}"
+    }
    ]
 }

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/security-groups.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/security-groups.yaml.j2
@@ -14,6 +14,10 @@ Parameters:
     Default: true
     Description: Deploy NAT resources or not
     Type: String
+  DeployTPResources:
+    Default: true
+    Description: Deploy Transparent Proxy resources or not
+    Type: String
   DeployVPNResources:
     Default: true
     Description: Deploy VPN resources or not
@@ -58,6 +62,7 @@ Parameters:
 Conditions:
   WAFInstanceCondition: !Equals [!Ref DeployWAFResources, true]
   NATInstanceCondition: !Equals [!Ref DeployNATResources, true]
+  TPInstanceCondition: !Equals [!Ref DeployTPResources, true]
   VPNInstanceCondition: !Equals [!Ref DeployVPNResources, true]
   BastionInstanceCondition: !Equals [!Ref DeployVPNResources, true]
 
@@ -401,6 +406,55 @@ Resources:
 
   ### VPC Project
 
+  TPInstanceSecurityGroup:
+    Condition: TPInstanceCondition
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enables outbound internet access for the VPC via the upstream NAT instances
+      VpcId: !Ref VPCProjectID
+      SecurityGroupEgress:
+      - CidrIp: !Ref VPCAdminCIDR
+        FromPort: '-1'
+        IpProtocol: '-1'
+        ToPort: '-1'
+      - CidrIp: !Ref VPCCiapCIDR
+        FromPort: '-1'
+        IpProtocol: '-1'
+        ToPort: '-1'
+      - CidrIp: !Ref VPCProjectCIDR
+        FromPort: '-1'
+        IpProtocol: '-1'
+        ToPort: '-1'
+      - CidrIp: !Ref VPCTechCIDR
+        FromPort: '-1'
+        IpProtocol: '-1'
+        ToPort: '-1'
+      - CidrIp: 169.254.169.254/32
+        FromPort: '-1'
+        IpProtocol: '-1'
+        ToPort: '-1'
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: !Ref VPCProjectCIDR
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: !Ref VPCProjectCIDR
+      - IpProtocol: tcp
+        FromPort: !Ref 'SquidPort'
+        ToPort: !Ref 'SquidPort'
+        CidrIp: !Ref VPCProjectCIDR
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        SourceSecurityGroupId: !Ref BastionInstanceSecurityGroup
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'Project-TPInstance']]
+
+
 
 Outputs:
   WAFInstanceSecurityGroupID:
@@ -413,6 +467,11 @@ Outputs:
     Description: NAT Instance Security Group ID
     Export:
       Name: !Sub ${AWS::StackName}-NATInstanceSecurityGroupID
+  TPInstanceSecurityGroupID:
+    Value: !Ref TPInstanceSecurityGroup
+    Description: Transparent Proxy Instance Security Group ID
+    Export:
+      Name: !Sub ${AWS::StackName}-TPInstanceSecurityGroupID
   WAFELBSecurityGroupID:
     Value: !Ref WAFELBSecurityGroup
     Description: WAF ELB Security Group ID

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/launch.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/launch.yaml
@@ -63,7 +63,6 @@
     - security-groups.yaml
     - network-functions.yaml
     - project-ocp-infra.yaml
-    - roles-logs-profiles.yaml
     - bootstrap/waf/etc/nginx/conf.d/virtual-ocp.conf
   when: create_infra == "yes"
 
@@ -97,7 +96,15 @@
   when: create_infra == "yes"
   register: cfnet
 
-- name: Create Roles, Instance Profiles and CloudWatch-Logs 
+- name: Rendering Roles, Logs and Profiles Templates
+  template:
+    src: roles/cloudformation-infra/files/{{ item }}.j2
+    dest: roles/cloudformation-infra/files/rendered/{{ stack_name }}/{{ item }}
+  with_items:
+    - roles-logs-profiles.yaml
+  when: create_infra == "yes"
+
+- name: Create Roles, Instance Profiles and CloudWatch-Logs
   cloudformation:
     stack_name: "{{ stack_name }}-rlp"
     state: "present"
@@ -121,6 +128,11 @@
 - name: Saving NATEC2Role instance role_id
   iam_role_facts: name="{{ cfrlp['stack_outputs']['NATEC2Role'] }}"
   register: roleid_NATEC2Role
+  when: create_infra == "yes"
+
+- name: Saving TPEC2Role instance role_id
+  iam_role_facts: name="{{ cfrlp['stack_outputs']['TPEC2Role'] }}"
+  register: roleid_TPEC2Role
   when: create_infra == "yes"
 
 - name: Saving VPNEC2Role instance role_id
@@ -249,8 +261,12 @@
       CiapVPNSubNet2ID: "{{ cfnet['stack_outputs']['CiapVPNSubNet2ID'] }}"
       AdminSubNet1ID: "{{ cfnet['stack_outputs']['AdminSubNet1ID'] }}"
       AdminSubNet2ID: "{{ cfnet['stack_outputs']['AdminSubNet2ID'] }}"
+      ProjectSubNet1ID: "{{ cfnet['stack_outputs']['ProjectSubNet1ID'] }}"
+      ProjectSubNet2ID: "{{ cfnet['stack_outputs']['ProjectSubNet2ID'] }}"
+      ProjectSubNet3ID: "{{ cfnet['stack_outputs']['ProjectSubNet3ID'] }}"
       SquidPort: "{{ squid_port }}"
-      SquidDist: "{{ squid_dist }}"
+      # Reached max parameters, need to remove this one
+      # SquidDist: "{{ squid_dist }}"
       VPCCiapID: "{{ cfnet['stack_outputs']['VPCCiapID'] }}"
       S3BucketPrefix: "{{ s3_bucket_prefix | lower }}"
     tags:


### PR DESCRIPTION
Basic implementation to fix issue #1.

Changes are:
- creation of a launch configuration to provision the proxy instance
- creation of an autoscaling group to make sure there is always one
  instance up and running
- creation of a security group allowing traffic on ports 80, 443 and 3128
- creation of an instance profile to grant the proxy instance enough
  privileges to reconfigure the RouteTable
- creation of bootstrap scripts to configure the proxy instance at startup
  and to reconfigure the Project VPC RouteTable so that traffic is routed
  through the transparent proxy
- minor fixes identified during feature implementation