### PR TITLE
Installation process now uses IAM roles to deploy CloudFormation

### DIFF
--- a/reference-architecture/aws-ansible/cip-on-aws.py
+++ b/reference-architecture/aws-ansible/cip-on-aws.py
@@ -418,7 +418,7 @@ def launch_oil_env(task=None,
 if __name__ == '__main__':
   # check for AWS access info
   if os.getenv('AWS_ACCESS_KEY_ID') is None or os.getenv('AWS_SECRET_ACCESS_KEY') is None:
-    print 'ERROR: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY **MUST** be exported as environment variables.'
+    print('ERROR: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY **MUST** be exported as environment variables.')
     sys.exit(1)
 
   launch_oil_env(auto_envvar_prefix='ITON_CIAP')

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/role-policy-oip-installer.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/role-policy-oip-installer.json.j2
@@ -4,6 +4,16 @@
     {
       "Effect": "Allow",
       "Action": [
+                  "s3:ListBucket*",
+                  "s3:ListAllMyBuckets",
+                  "s3:GetBucketLocation",
+                  "s3:ListBucketMultipartUploads"
+        ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
           "s3:*"
         ],
       "Resource": [

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/launch.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/launch.yaml
@@ -12,10 +12,14 @@
         Principal:
           AWS: arn:aws:iam::{{ root_account['account_id'] }}:user/{{ root_account['iam_user'] }}
           Service: ec2.amazonaws.com
+          Service: cloudformation.amazonaws.com
   register: iam
 
 - name: Saving installer role ID
   set_fact: installer_role_id="{{ iam['role_result']['role_id'] }}"
+
+- name: Saving installer role ARN
+  set_fact: installer_role_arn="{{ iam['role_result']['arn'] }}"
 
 
 - name: Creating rendered files directories
@@ -30,6 +34,7 @@
     - "{{ stack_name }}/bootstrap/common"
     - "{{ stack_name }}/bootstrap/common/pubkeys"
     - "{{ stack_name }}/bootstrap/nat"
+    - "{{ stack_name }}/bootstrap/tp"
     - "{{ stack_name }}/bootstrap/vpn"
     - "{{ stack_name }}/bootstrap/waf"
     - "{{ stack_name }}/bootstrap/waf/etc/nginx/conf.d"
@@ -71,7 +76,8 @@
     stack_name: "{{ stack_name }}-net"
     state: "present"
     region: "{{ region }}"
-    profile: "{{ aws_cli_installer_profile }}"
+    #profile: "{{ aws_cli_installer_profile }}"
+    role_arn: "{{ installer_role_arn }}"
     template: "roles/cloudformation-infra/files/rendered/{{ stack_name }}/network.yaml"
     template_parameters:
       NumberOfAZs: "3"
@@ -109,7 +115,8 @@
     stack_name: "{{ stack_name }}-rlp"
     state: "present"
     region: "{{ region }}"
-    profile: "{{ aws_cli_installer_profile }}"
+    #profile: "{{ aws_cli_installer_profile }}"
+    role_arn: "{{ installer_role_arn }}"
     template: "roles/cloudformation-infra/files/rendered/{{ stack_name }}/roles-logs-profiles.yaml"
     template_parameters:
       S3BucketPrefix: "{{ s3_bucket_prefix | lower }}"
@@ -172,7 +179,8 @@
     stack_name: "{{ stack_name }}-secgrp"
     state: "present"
     region: "{{ region }}"
-    profile: "{{ aws_cli_installer_profile }}"
+    #profile: "{{ aws_cli_installer_profile }}"
+    role_arn: "{{ installer_role_arn }}"
     template: "roles/cloudformation-infra/files/rendered/{{ stack_name }}/security-groups.yaml"
     template_parameters:
       VPCCiapID: "{{ cfnet['stack_outputs']['VPCCiapID'] }}"
@@ -189,7 +197,7 @@
   register: cfsecgrp
 
 - name: Bootstrap generating the list of templates to process, formatted as a json list
-  command: python -c 'import os, json; print json.dumps([os.path.join(dp, f)[2:] for dp, dn, fn in os.walk(os.path.expanduser(".")) for f in fn if f.endswith(".j2")])'
+  command: python -c 'import os, json; print(json.dumps([os.path.join(dp, f)[2:] for dp, dn, fn in os.walk(os.path.expanduser(".")) for f in fn if f.endswith(".j2")]))'
   args:
     chdir: roles/cloudformation-infra/files/bootstrap
   register: bootstrap_files_cmd
@@ -214,7 +222,8 @@
     stack_name: "{{ stack_name }}-netfunc"
     state: "present"
     region: "{{ region }}"
-    profile: "{{ aws_cli_installer_profile }}"
+    #profile: "{{ aws_cli_installer_profile }}"
+    role_arn: "{{ installer_role_arn }}"
     template: "roles/cloudformation-infra/files/rendered/{{ stack_name }}/network-functions.yaml"
     template_parameters:
       NumberOfAZs: "2"
@@ -313,7 +322,8 @@
     stack_name: "{{ stack_name }}-project-ocp-inf"
     state: "present"
     region: "{{ region }}"
-    profile: "{{ aws_cli_installer_profile }}"
+    #profile: "{{ aws_cli_installer_profile }}"
+    role_arn: "{{ installer_role_arn }}"
     template: "roles/cloudformation-infra/files/rendered/{{ stack_name }}/project-ocp-infra.yaml"
     template_parameters:
       NumberOfAZs: "3"


### PR DESCRIPTION
Stacks (issue #5).

A fix to issue #4 - migrate to Python 3 is also included.