### PR TITLE
Issue 8 replace vpc peering with transit gateway

### DIFF
--- a/reference-architecture/aws-ansible/README.md
+++ b/reference-architecture/aws-ansible/README.md
@@ -63,22 +63,23 @@ to make sure your design will scale and allow future use case.
 
 The following segmentation would fit most needs.
 
-| VPC     | CIDR          | # IPs  | Subnet   | Comments |
-|---------|--------------:|-------:|----------|----------|
-| CIAP    | 10.0.0.0/20   | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
-| Admin   | 10.0.16.0/20  | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
-| Tech    | 10.0.32.0/20  | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
-| Project | 10.0.128.0/17 | 32766  | supernet | Many subnets for various usage, aPaaS, CaaS, EC2 instances, etc. |
-| Project | 10.0.128.0/24 | 254    | OpenShift Pub 1 | Public Subnet for OpenShift in AZ 1 |
-| Project | 10.0.129.0/24 | 254    | OpenShift Pub 2 | Public Subnet for OpenShift in AZ 2 |
-| Project | 10.0.130.0/24 | 254    | OpenShift Pub 3 | Public Subnet for OpenShift in AZ 3 |
-| Project | 10.0.131.0/24 | 254    | OpenShift Pub 4 | Reserving for Public Subnet for OpenShift in AZ 4 |
-| Project | 10.0.132.0/24 | 254    | OpenShift Priv 1 | Private Subnet for OpenShift in AZ 1 |
-| Project | 10.0.133.0/24 | 254    | OpenShift Priv 2 | Private Subnet for OpenShift in AZ 2 |
-| Project | 10.0.134.0/24 | 254    | OpenShift Priv 3 | Private Subnet for OpenShift in AZ 3 |
-| Project | 10.0.135.0/24 | 254    | OpenShift Priv 4 | Reserving for Private Subnet for OpenShift in AZ 4 |
+| VPC             | CIDR          | # IPs  | Subnet   | Comments |
+|-----------------|--------------:|-------:|----------|----------|
+| CIAP (Hosting)  | 10.0.0.0/20   | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
+| Admin           | 10.0.16.0/20  | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
+| Tech            | 10.0.32.0/20  | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
+| CIAP (Browsing) | 10.0.48.0/20  | 4094   | supernet | 1 subnet per AZ, max 1022 IP/AZ, seems enough |
+| Project         | 10.0.128.0/17 | 32766  | supernet | Many subnets for various usage, aPaaS, CaaS, EC2 instances, etc. |
+| Project         | 10.0.128.0/24 | 254    | OpenShift Pub 1 | Public Subnet for OpenShift in AZ 1 |
+| Project         | 10.0.129.0/24 | 254    | OpenShift Pub 2 | Public Subnet for OpenShift in AZ 2 |
+| Project         | 10.0.130.0/24 | 254    | OpenShift Pub 3 | Public Subnet for OpenShift in AZ 3 |
+| Project         | 10.0.131.0/24 | 254    | OpenShift Pub 4 | Reserving for Public Subnet for OpenShift in AZ 4 |
+| Project         | 10.0.132.0/24 | 254    | OpenShift Priv 1 | Private Subnet for OpenShift in AZ 1 |
+| Project         | 10.0.133.0/24 | 254    | OpenShift Priv 2 | Private Subnet for OpenShift in AZ 2 |
+| Project         | 10.0.134.0/24 | 254    | OpenShift Priv 3 | Private Subnet for OpenShift in AZ 3 |
+| Project         | 10.0.135.0/24 | 254    | OpenShift Priv 4 | Reserving for Private Subnet for OpenShift in AZ 4 |
 
-At time of writing, VPC CIDR on AWS are limited to /16 (65534 IP addresses). 
+At time of writing, VPC CIDR on AWS are limited to /16 (65534 IP addresses).
 
 
 
@@ -111,7 +112,7 @@ $ cp playbooks/vars/main.yaml.sample playbooks/vars/main.yaml
 $ ./cip-on-aws.py -v --task=launch --stack-name=cip-dev \
                      --public-dns-domain=cip-dev.domain.com \
                      --private-dns-domain=cip-dev.domain.priv \
-                     --keypair=aws-key-pair-name 
+                     --keypair=aws-key-pair-name
 ```
 
 5. Trigger the OpenShift admin, master, infra and worker nodes creation

--- a/reference-architecture/aws-ansible/playbooks/account-setup.yaml
+++ b/reference-architecture/aws-ansible/playbooks/account-setup.yaml
@@ -4,7 +4,7 @@
   gather_facts: no
   become: no
   vars_files:
-  - vars/main.yaml
+  - vars/{{ stack_name }}.yaml
   roles:
   - role: account-setup
     when: root_account['setup'] == 'yes'

--- a/reference-architecture/aws-ansible/playbooks/infrastructure.yaml
+++ b/reference-architecture/aws-ansible/playbooks/infrastructure.yaml
@@ -4,7 +4,7 @@
   gather_facts: no
   become: no
   vars_files:
-  - vars/main.yaml
+  - vars/{{stack_name}}.yaml
   vars:
     vpc_subnet_azs: "{{ lookup('ec2_zones_by_region', region) }}"
     teardown_infra: "no"

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/bootstrap/tp/bootstrap-tp.sh.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/bootstrap/tp/bootstrap-tp.sh.j2
@@ -76,7 +76,8 @@ generate_squid_config() {
   cache_effective_group squid
   cache_effective_user squid
 
-  http_port 3128 transparent
+  http_port 3128 require-proxy-header
+  http_port 3129 transparent
   #https_port 3130 intercept ssl-bump cert=/etc/squid/ssl_cert/myCA.pem generate-host-certificates=on dynamic_cert_mem_cache_size=4MB  options=NO_SSLv2,NO_SSLv3,NO_TLSv1,NO_TLSv1_1,NO_TICKET cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
   https_port 3130 intercept ssl-bump cert=/etc/squid/ssl_cert/myCA.pem
 
@@ -149,25 +150,29 @@ install_and_run_squid() {
 }
 
 set_as_router() {
+  # Logic: find the region, zone and AZ of the instance then find out the
+  #        custom route table associated with the private subnetid of this
+  #        AZ and finaly set a new default route within that route table
+  #        pointing to the ENI of this instance
   echo "-> Adding IPTables rules to forward port 80 and 443 to the transparent Squid instance"
-  iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 3128
+  iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 3129
   iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 3130
 
   II_URI="http://169.254.169.254/latest/dynamic/instance-identity/document"
-  # Set AZ of NAT instance
-  REGION=`curl --retry 3 --retry-delay 0 --silent --fail $II_URI | grep region | awk -F\" '{print $4}'`
-  INSTANCE_ID=`curl --retry 3 --retry-delay 0 --silent --fail $II_URI | grep instanceId | awk -F\" '{print $4}'`
-  VPC_ID=`aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[*].Instances[*].VpcId' --region $REGION --output text`
-  #TODO: Since the current automation creates a secondary route table, we need to pick a non 'main' route.
-  #      it works since there is only one such route table. Automation should be changed to use default route tables instead of specific one.
-  #MAIN_RT=`aws ec2 describe-route-tables --query 'RouteTables[*].RouteTableId' --filters Name=vpc-id,Values=$VPC_ID Name=association.main,Values=true --region $REGION --output text`
-  MAIN_RT=`aws ec2 describe-route-tables --query 'RouteTables[*].RouteTableId' --filters Name=vpc-id,Values=$VPC_ID Name=association.main,Values=false --region $REGION --output text`
+  REGION=$(curl --retry 3 --retry-delay 0 --silent --fail $II_URI | grep region | awk -F\" '{print $4}')
+  INSTANCE_ID=$(curl --retry 3 --retry-delay 0 --silent --fail $II_URI | grep instanceId | awk -F\" '{print $4}')
+  VPC_ID=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[*].Instances[*].VpcId' --region $REGION --output text)
+  AZ=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[*].Instances[*].Placement.AvailabilityZone' --region $REGION --output text)
+  SUBNET_ID=$(aws ec2 describe-subnets --filters "Name=tag:Network,Values=CIAP_Browsing_Private" "Name=availability-zone,Values=$AZ" --query Subnets[*].SubnetId --region $REGION --output text)
+  MAIN_RT=$(aws ec2 describe-route-tables --filters "Name=association.subnet-id,Values=$SUBNET_ID" --query 'RouteTables[*].RouteTableId' --region $REGION --output text)
 
   # Printing some debuging information...
   cat <<EOT
   Transparent SQUID proxy - Initializing
   - Region: $REGION
+  - Availability Zone: $AZ
   - VPC ID: $VPC_ID
+  - Subnet ID: $SUBNET_ID
   - Instance ID: $INSTANCE_ID
   - Route table: $MAIN_RT
 EOT

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network-functions.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network-functions.yaml.j2
@@ -1058,37 +1058,205 @@ Resources:
 
   ### VPC Tech
 
-  ### VPC Project
+  ### VPC CIAPBrowsing
+
+  ### BEGIN NAT2 instance / Squid proxy
+  NAT2AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      LaunchConfigurationName: !Ref NAT2AutoScalingLaunchConfiguration
+      LoadBalancerNames:
+      - !Ref NAT2ElasticLoadBalancer
+      DesiredCapacity: 1
+      MinSize: 1
+      MaxSize: 10
+      VPCZoneIdentifier:
+{% for idx in range(1, ciap_nb_subnets|int + 1) %}
+      - Fn::ImportValue:
+          !Sub {{ stack_name }}-net-CiapBrowsingPublicSubnet{{ idx }}ID
+{% endfor %}
+      HealthCheckType: ELB
+      HealthCheckGracePeriod: 300
+      Tags:
+      - PropagateAtLaunch: true
+        Key: "Name"
+        Value: "NAT Instance"
+      - PropagateAtLaunch: true
+        Key: "Function"
+        Value: "NAT"
+
+  NAT2AutoScalingLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      IamInstanceProfile: !Ref NATEC2InstanceProfile
+      AssociatePublicIpAddress: true
+      InstanceType: !Ref NATInstanceType
+      KeyName: !Ref KeyPairName
+      SecurityGroups:
+      - Fn::ImportValue:
+          !Sub {{ stack_name }}-secgrp-NAT2InstanceSecurityGroupID
+      ImageId: !FindInMap [AWSAMIRegionMap, !Ref 'AWS::Region', 'AWSNATHVM']
+      InstanceMonitoring: false
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          echo "MY-CLOUD-INIT-SCRIPT: Start"
+          export NETFUNC=nat
+
+          # Make sure we have internet access
+          CMD='curl -sL -w "%{http_code}" "https://s3.eu-west-1.amazonaws.com/" -o /dev/null --retry 5 --max-time 3'
+          while [ "$(eval $CMD)" != "200" ]; do
+            # No proxy defined here as NAT instances ARE the proxies...
+            #echo "MY-CLOUD-INIT-SCRIPT: NAT instance(s) not ready, sleeping 5 seconds"
+            echo "MY-CLOUD-INIT-SCRIPT: Unable to access test endpoint, sleeping 5 seconds"
+            sleep 5
+          done
+
+          cd /root
+
+          # Common bootstrap
+          echo "MY-CLOUD-INIT-SCRIPT: Fetching common bootstrap script"
+          aws s3 cp s3://${S3Location}/bootstrap/common/bootstrap.sh ./
+          chmod +x ./bootstrap.sh
+          echo "MY-CLOUD-INIT-SCRIPT: Launching common bootstrap script"
+          ./bootstrap.sh ${AWS::StackName} ${NATCloudWatchLogsGroup} ${S3Location} 2>&1 | tee /var/log/oil-bootstrap
+
+          # Function-specific bootstrap
+          echo "MY-CLOUD-INIT-SCRIPT: Fetching '$NETFUNC-specific' bootstrap script & launching it"
+          NFSCRIPT="bootstrap-${!NETFUNC}.sh"
+          aws s3 cp s3://${S3Location}/bootstrap/$NETFUNC/$NFSCRIPT ./
+          chmod +x ./$NFSCRIPT
+          ./$NFSCRIPT zip ${SquidPort} ${AWS::StackName} ${NATCloudWatchLogsGroup} ${S3Location } 2>&1 | tee /var/log/oil-bootstrap-${!NETFUNC}
+          echo "MY-CLOUD-INIT-SCRIPT: Done!"
+
+  NAT2ElasticLoadBalancer:
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
+    Properties:
+      SecurityGroups:
+      - Fn::ImportValue:
+          !Sub {{ stack_name }}-secgrp-NAT2ELBSecurityGroupID
+      Subnets:
+{% for idx in range(1, ciap_nb_subnets|int + 1) %}
+      - Fn::ImportValue:
+          !Sub {{ stack_name }}-net-CiapBrowsingPublicSubnet{{ idx }}ID
+{% endfor %}
+      Listeners:
+      - LoadBalancerPort: !Ref SquidPort
+        InstancePort: !Ref SquidPort
+        Protocol: TCP
+      - LoadBalancerPort: !Ref SquidPortInt80
+        InstancePort: !Ref SquidPortInt80
+        Protocol: TCP
+      - LoadBalancerPort: !Ref SquidPortInt443
+        InstancePort: !Ref SquidPortInt443
+        Protocol: TCP
+      - LoadBalancerPort: 22
+        InstancePort: 22
+        Protocol: TCP
+      ConnectionDrainingPolicy:
+        Enabled: true
+        Timeout: 60
+      Scheme: internal
+      HealthCheck:
+        HealthyThreshold: 6
+        Interval: 10
+        Target: !Join [':', [TCP, !Ref 'SquidPort']]
+        Timeout: 5
+        UnhealthyThreshold: 4
+      CrossZone: true
+      Policies:
+      #TODO: check if change needed for transparent proxy
+      - !If [SupportProxyProtocol, {PolicyName: EnableProxyProtocol, PolicyType: ProxyProtocolPolicyType,
+          Attributes: [{Name: ProxyProtocol, Value: 'true'}], InstancePorts: [!Ref 'SquidPort']},
+        !Ref 'AWS::NoValue']
+      AccessLoggingPolicy:
+        S3BucketName:
+          Ref: S3LogsLocation
+        S3BucketPrefix: ''
+        Enabled: true
+        EmitInterval: 5
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-NATELB']]
+
+  NAT2ScaleOutPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref 'NAT2AutoScalingGroup'
+      Cooldown: 300
+      ScalingAdjustment: 1
+
+  NAT2ScaleInPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref 'NAT2AutoScalingGroup'
+      Cooldown: 300
+      ScalingAdjustment: -1
+
+  NAT2AlarmScaleOutPolicy:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Scale out if average Squid traffic > 5000 KB/s for 5 minutes
+      MetricName: TotalKbytesPerSecond
+      Namespace: CIAP
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
+      Dimensions:
+      - Name: StackName
+        Value: !Ref AWS::StackName
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !Ref NAT2ScaleOutPolicy
+
+  NAT2AlarmScaleInPolicy:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Scale in if average Squid traffic < 2000 KB/s for 15 minutes
+      MetricName: TotalKbytesPerSecond
+      Namespace: CIAP
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 2000
+      Dimensions:
+      - Name: StackName
+        Value: !Ref AWS::StackName
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+      - !Ref NAT2ScaleInPolicy
+  ### END NAT2 instance / Squid proxy
+
 
   ### BEGIN Transparent proxy
   # Using some NAT* variables since we reached the maximum number of
   # CloudFormation parameters (60 as of writing)
-  TPAutoScalingGroup:
+
+{% for idx in range(1, ciap_nb_subnets|int + 1) %}
+  TPAutoScalingGroup{{ idx }}:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      LaunchConfigurationName: !Ref 'TPAutoScalingLaunchConfiguration'
-      #TargetGroupARNs:
-      #- !Ref TPELBTargetGroup80
-      #- !Ref TPELBTargetGroup443
-      #- !Ref TPELBTargetGroup3128
-      DesiredCapacity: '1'
-      MinSize: '1'
-      MaxSize: '10'
+      LaunchConfigurationName: !Ref TPAutoScalingLaunchConfiguration{{ idx }}
+      DesiredCapacity: 1
+      MinSize: 1
+      MaxSize: 10
       VPCZoneIdentifier:
-{% for idx in range(1, project_ocp_nb_subnets|int + 1) %}
-      - !Ref 'ProjectSubNet{{ idx }}ID'
-{% endfor %}
+      - Fn::ImportValue:
+          !Sub {{ stack_name }}-net-CiapBrowsingPublicSubnet{{ idx }}ID
       HealthCheckType: ELB
-      HealthCheckGracePeriod: '300'
+      HealthCheckGracePeriod: 300
       Tags:
       - PropagateAtLaunch: true
         Key: "Name"
-        Value: "{{ stack_name }}-project-tpinstance"
+        Value: "{{ stack_name }}-CIAPBrowsing-tpinstance{{ idx }}"
       - PropagateAtLaunch: true
         Key: "Function"
         Value: "TP"
 
-  TPAutoScalingLaunchConfiguration:
+  TPAutoScalingLaunchConfiguration{{ idx }}:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       IamInstanceProfile:
@@ -1144,59 +1312,58 @@ Resources:
             echo "MY-CLOUD-INIT-SCRIPT: Done!"
           - TPCloudWatchLogsGroup:
               Fn::ImportValue:
-                !Sub "{{ stack_name }}-rlp-TPCloudWatchLogsGroup"
+                !Sub {{ stack_name }}-rlp-TPCloudWatchLogsGroup
 
-  TPScaleOutPolicy:
+  TPScaleOutPolicy{{ idx }}:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref 'TPAutoScalingGroup'
-      Cooldown: '300'
-      ScalingAdjustment: '1'
+      AutoScalingGroupName: !Ref TPAutoScalingGroup{{ idx }}
+      Cooldown: 300
+      ScalingAdjustment: 1
 
-  TPScaleInPolicy:
+  TPScaleInPolicy{{ idx }}:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref 'TPAutoScalingGroup'
-      Cooldown: '300'
-      ScalingAdjustment: '-1'
+      AutoScalingGroupName: !Ref TPAutoScalingGroup{{ idx }}
+      Cooldown: 300
+      ScalingAdjustment: -1
 
-  TPAlarmScaleOutPolicy:
+  TPAlarmScaleOutPolicy{{ idx }}:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: Scale out if average Squid traffic > 5000 KB/s for 5 minutes
       MetricName: TotalKbytesPerSecond
       Namespace: CIAP
       Statistic: Average
-      Period: '300'
-      EvaluationPeriods: '1'
-      Threshold: '5000'
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5000
       Dimensions:
       - Name: StackName
-        Value: !Ref 'AWS::StackName'
+        Value: !Ref AWS::StackName
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-      - !Ref 'TPScaleOutPolicy'
+      - !Ref TPScaleOutPolicy{{ idx }}
 
-  TPAlarmScaleInPolicy:
+  TPAlarmScaleInPolicy{{ idx }}:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: Scale in if average Squid traffic < 2000 KB/s for 15 minutes
       MetricName: TotalKbytesPerSecond
       Namespace: CIAP
       Statistic: Average
-      Period: '300'
-      EvaluationPeriods: '3'
-      Threshold: '2000'
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 2000
       Dimensions:
       - Name: StackName
-        Value: !Ref 'AWS::StackName'
+        Value: !Ref AWS::StackName
       ComparisonOperator: LessThanThreshold
       AlarmActions:
-      - !Ref 'TPScaleInPolicy'
-
-
+      - !Ref TPScaleInPolicy{{ idx }}
+{% endfor %}
   ### END Transparent proxy
 
 

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network-functions.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network-functions.yaml.j2
@@ -1146,107 +1146,6 @@ Resources:
               Fn::ImportValue:
                 !Sub "{{ stack_name }}-rlp-TPCloudWatchLogsGroup"
 
-
-#  TPElasticLoadBalancer:
-#    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-#    Properties:
-#      Type: network
-#      IpAddressType: ipv4
-#      LoadBalancerAttributes:
-#        - Key: access_logs.s3.enabled
-#          Value: True
-#        - Key: access_logs.s3.bucket
-#          Value: !Ref S3LogsLocation
-#        - Key: access_logs.s3.prefix
-#          Value: ''
-#        - Key: deletion_protection.enabled
-#          Value: False
-#        - Key: load_balancing.cross_zone.enabled
-#          Value: True
-#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PROJECT-TPELB']]
-#      Scheme: internal
-#      Subnets:
-#{% for idx in range(1, project_nb_subnets|int + 1) %}
-#        - !Ref 'ProjectSubNet{{ idx }}ID'
-#{% endfor %}
-#      Tags:
-#        - Key: StackName
-#          Value: !Ref 'AWS::StackName'
-#
-#  TPELBTargetGroup80:
-#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-#    Properties:
-#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PRJ-TPELBTG80']]
-#      Port: 80
-#      Protocol: TCP
-#      VpcId:
-#        Fn::ImportValue:
-#          !Sub "{{ stack_name }}-net-VPCProjectID"
-#      TargetGroupAttributes:
-#        - Key: deregistration_delay.timeout_seconds
-#          Value: 60
-#      Tags:
-#        - Key: StackName
-#          Value: !Ref 'AWS::StackName'
-#  TPELBTargetGroup443:
-#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-#    Properties:
-#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PRJ-TPELBTG443']]
-#      Port: 443
-#      Protocol: TCP
-#      VpcId:
-#        Fn::ImportValue:
-#          !Sub "{{ stack_name }}-net-VPCProjectID"
-#      TargetGroupAttributes:
-#        - Key: deregistration_delay.timeout_seconds
-#          Value: 60
-#      Tags:
-#        - Key: StackName
-#          Value: !Ref 'AWS::StackName'
-#  TPELBTargetGroup3128:
-#    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-#    Properties:
-#      Name: !Join ['-', [!Ref 'AWS::StackName', 'PRJ-TPELBTG3128']]
-#      Port: 3128
-#      Protocol: TCP
-#      VpcId:
-#        Fn::ImportValue:
-#          !Sub "{{ stack_name }}-net-VPCProjectID"
-#      TargetGroupAttributes:
-#        - Key: deregistration_delay.timeout_seconds
-#          Value: 60
-#      Tags:
-#        - Key: StackName
-#          Value: !Ref 'AWS::StackName'
-#
-#  TPELBListener80:
-#    Type: AWS::ElasticLoadBalancingV2::Listener
-#    Properties:
-#      DefaultActions:
-#      - Type: forward
-#        TargetGroupArn: !Ref TPELBTargetGroup80
-#      LoadBalancerArn: !Ref TPElasticLoadBalancer
-#      Port: '80'
-#      Protocol: TCP
-#  TPELBListener443:
-#    Type: AWS::ElasticLoadBalancingV2::Listener
-#    Properties:
-#      DefaultActions:
-#      - Type: forward
-#        TargetGroupArn: !Ref TPELBTargetGroup443
-#      LoadBalancerArn: !Ref TPElasticLoadBalancer
-#      Port: '443'
-#      Protocol: TCP
-#  TPELBListener3128:
-#    Type: AWS::ElasticLoadBalancingV2::Listener
-#    Properties:
-#      DefaultActions:
-#      - Type: forward
-#        TargetGroupArn: !Ref TPELBTargetGroup3128
-#      LoadBalancerArn: !Ref TPElasticLoadBalancer
-#      Port: '3128'
-#      Protocol: TCP
-#
   TPScaleOutPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
@@ -1314,12 +1213,6 @@ Outputs:
   WAFDNSName:
     Description: DNS Name of WAF proxy ELB
     Value: !GetAtt [WAFElasticLoadBalancer, DNSName]
-#  TPELBName:
-#    Description: Name of Transparent proxy ELB
-#    Value: !Ref 'TPElasticLoadBalancer'
-#  TPDNSName:
-#    Description: DNS Name of Transparent proxy ELB
-#    Value: !GetAtt [TPElasticLoadBalancer, DNSName]
   SquidELBName:
     Description: Name of Squid proxy ELB
     Value: !Ref 'NATElasticLoadBalancer'

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network.yaml.j2
@@ -9,7 +9,7 @@ Parameters:
     - 3
     - 4
     Default: 2
-    Description: .
+    Description: Nb AZs.
     Type: String
   DeployWAFResources:
     Default: true
@@ -175,34 +175,13 @@ Resources:
       RouteTableId: !Ref CiapRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
-  CiapRoute2Admin:
-    Type: AWS::EC2::Route
-    DependsOn: VPCCiap2AdminPeeringConnection
-    Properties:
-      RouteTableId: !Ref CiapRouteTable
-      DestinationCidrBlock: !Ref VPCAdminCIDR
-      VpcPeeringConnectionId: !Ref VPCCiap2AdminPeeringConnection
-  CiapRoute2Browsing:
+  CiapRoute2TGW:
     Type: AWS::EC2::Route
     DependsOn: TransitGatewayAttachmentCiap
     Properties:
       RouteTableId: !Ref CiapRouteTable
-      DestinationCidrBlock: 10.0.48.0/20
+      DestinationCidrBlock: 10.0.0.0/8
       TransitGatewayId: !Ref TransitGateway1
-  CiapRoute2Tech:
-    Type: AWS::EC2::Route
-    DependsOn: VPCCiap2TechPeeringConnection
-    Properties:
-      RouteTableId: !Ref CiapRouteTable
-      DestinationCidrBlock: !Ref VPCTechCIDR
-      VpcPeeringConnectionId: !Ref VPCCiap2TechPeeringConnection
-  CiapRoute2Project:
-    Type: AWS::EC2::Route
-    DependsOn: VPCCiap2ProjectPeeringConnection
-    Properties:
-      RouteTableId: !Ref CiapRouteTable
-      DestinationCidrBlock: !Ref VPCProjectCIDR
-      VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
 {% for idx in range(1, ciap_nb_subnets|int + 1) %}
   CiapHostingSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
@@ -263,36 +242,6 @@ Resources:
       SubnetId: !Ref CiapVPNSubNet{{ idx }}
       RouteTableId: !Ref CiapRouteTable
 {% endfor %}
-  VPCCiap2AdminPeeringConnection:
-    Type: AWS::EC2::VPCPeeringConnection
-    Properties:
-      VpcId:
-        Ref: VPCCiap
-      PeerVpcId:
-        Ref: VPCAdmin
-      Tags:
-      - Key: Name
-        Value: !Join ['-', [!Ref 'AWS::StackName', 'Ciap2Admin']]
-  VPCCiap2TechPeeringConnection:
-    Type: AWS::EC2::VPCPeeringConnection
-    Properties:
-      VpcId:
-        Ref: VPCCiap
-      PeerVpcId:
-        Ref: VPCTech
-      Tags:
-      - Key: Name
-        Value: !Join ['-', [!Ref 'AWS::StackName', 'Ciap2Tech']]
-  VPCCiap2ProjectPeeringConnection:
-    Type: AWS::EC2::VPCPeeringConnection
-    Properties:
-      VpcId:
-        Ref: VPCCiap
-      PeerVpcId:
-        Ref: VPCProject
-      Tags:
-      - Key: Name
-        Value: !Join ['-', [!Ref 'AWS::StackName', 'Ciap2Project']]
   VPCCiapS3VPCEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
@@ -664,27 +613,13 @@ Resources:
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Admin-RouteTable']]
       - Key: Network
         Value: Admin
-  AdminRoute2Ciap:
+  AdminRoute2TGW:
     Type: AWS::EC2::Route
-    DependsOn: VPCCiap2AdminPeeringConnection
+    DependsOn: TransitGatewayAttachmentAdmin
     Properties:
       RouteTableId: !Ref AdminRouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      VpcPeeringConnectionId: !Ref VPCCiap2AdminPeeringConnection
-  AdminRoute2Tech:
-    Type: AWS::EC2::Route
-    DependsOn: VPCAdmin2TechPeeringConnection
-    Properties:
-      RouteTableId: !Ref AdminRouteTable
-      DestinationCidrBlock: !Ref VPCTechCIDR
-      VpcPeeringConnectionId: !Ref VPCAdmin2TechPeeringConnection
-  AdminRoute2Project:
-    Type: AWS::EC2::Route
-    DependsOn: VPCAdmin2ProjectPeeringConnection
-    Properties:
-      RouteTableId: !Ref AdminRouteTable
-      DestinationCidrBlock: !Ref VPCProjectCIDR
-      VpcPeeringConnectionId: !Ref VPCAdmin2ProjectPeeringConnection
+      TransitGatewayId: !Ref TransitGateway1
 {% for idx in range(1, admin_nb_subnets|int + 1) %}
   AdminSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
@@ -706,26 +641,6 @@ Resources:
       SubnetId: !Ref AdminSubNet{{ idx }}
       RouteTableId: !Ref AdminRouteTable
 {% endfor %}
-  VPCAdmin2TechPeeringConnection:
-    Type: AWS::EC2::VPCPeeringConnection
-    Properties:
-      VpcId:
-        Ref: VPCAdmin
-      PeerVpcId:
-        Ref: VPCTech
-      Tags:
-      - Key: Name
-        Value: !Join ['-', [!Ref 'AWS::StackName', 'Admin2Tech']]
-  VPCAdmin2ProjectPeeringConnection:
-    Type: AWS::EC2::VPCPeeringConnection
-    Properties:
-      VpcId:
-        Ref: VPCAdmin
-      PeerVpcId:
-        Ref: VPCProject
-      Tags:
-      - Key: Name
-        Value: !Join ['-', [!Ref 'AWS::StackName', 'Admin2Project']]
   VPCAdminS3VPCEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
@@ -784,27 +699,13 @@ Resources:
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Tech-RouteTable']]
       - Key: Network
         Value: Tech
-  TechRoute2Ciap:
+  TechRoute2TGW:
     Type: AWS::EC2::Route
-    DependsOn: VPCCiap2TechPeeringConnection
+    DependsOn: TransitGatewayAttachmentTech
     Properties:
       RouteTableId: !Ref TechRouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      VpcPeeringConnectionId: !Ref VPCCiap2TechPeeringConnection
-  TechRoute2Admin:
-    Type: AWS::EC2::Route
-    DependsOn: VPCAdmin2TechPeeringConnection
-    Properties:
-      RouteTableId: !Ref TechRouteTable
-      DestinationCidrBlock: !Ref VPCAdminCIDR
-      VpcPeeringConnectionId: !Ref VPCAdmin2TechPeeringConnection
-  TechRoute2Project:
-    Type: AWS::EC2::Route
-    DependsOn: VPCTech2ProjectPeeringConnection
-    Properties:
-      RouteTableId: !Ref TechRouteTable
-      DestinationCidrBlock: !Ref VPCProjectCIDR
-      VpcPeeringConnectionId: !Ref VPCTech2ProjectPeeringConnection
+      TransitGatewayId: !Ref TransitGateway1
 {% for idx in range(1, tech_nb_subnets|int + 1) %}
   TechSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
@@ -826,16 +727,6 @@ Resources:
       SubnetId: !Ref TechSubNet{{ idx }}
       RouteTableId: !Ref TechRouteTable
 {% endfor %}
-  VPCTech2ProjectPeeringConnection:
-    Type: AWS::EC2::VPCPeeringConnection
-    Properties:
-      VpcId:
-        Ref: VPCTech
-      PeerVpcId:
-        Ref: VPCProject
-      Tags:
-      - Key: Name
-        Value: !Join ['-', [!Ref 'AWS::StackName', 'Tech2Project']]
   VPCTechS3VPCEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
@@ -920,32 +811,11 @@ Resources:
 {% endfor %}
   ProjectRoute2Default:
     Type: AWS::EC2::Route
-    DependsOn: VPCCiap2ProjectPeeringConnection
+    DependsOn: TransitGatewayAttachmentProject
     Properties:
       RouteTableId: !Ref ProjectRouteTable
       DestinationCidrBlock: 0.0.0.0/0
-      VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
-  ProjectRoute2Ciap:
-    Type: AWS::EC2::Route
-    DependsOn: VPCCiap2ProjectPeeringConnection
-    Properties:
-      RouteTableId: !Ref ProjectRouteTable
-      DestinationCidrBlock: !Ref VPCCiapCIDR
-      VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
-  ProjectRoute2Admin:
-    Type: AWS::EC2::Route
-    DependsOn: VPCAdmin2ProjectPeeringConnection
-    Properties:
-      RouteTableId: !Ref ProjectRouteTable
-      DestinationCidrBlock: !Ref VPCAdminCIDR
-      VpcPeeringConnectionId: !Ref VPCAdmin2ProjectPeeringConnection
-  ProjectRoute2Tech:
-    Type: AWS::EC2::Route
-    DependsOn: VPCTech2ProjectPeeringConnection
-    Properties:
-      RouteTableId: !Ref ProjectRouteTable
-      DestinationCidrBlock: !Ref VPCTechCIDR
-      VpcPeeringConnectionId: !Ref VPCTech2ProjectPeeringConnection
+      TransitGatewayId: !Ref TransitGateway1
   VPCProjectS3VPCEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
@@ -1035,6 +905,105 @@ Resources:
       TransitGatewayId: !Ref TransitGateway1
       VpcId: !Ref VPCCiapBrowsing
 
+  TransitGateway1RouteTable:
+    Type: AWS::EC2::TransitGatewayRouteTable
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-RT-CIAPBrowsing']]
+        - Key: OpenInnovationLabStack
+          Value: {{stack_name}}
+      TransitGatewayId: !Ref TransitGateway1
+
+  TransitGateway1DefaultRoute:
+    Type: AWS::EC2::TransitGatewayRoute
+    DependsOn: TransitGatewayAttachmentCiapBrowsing
+    Properties:
+      Blackhole: False
+      DestinationCidrBlock: 0.0.0.0/0
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentCiapBrowsing
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1Route2Ciap:
+    Type: AWS::EC2::TransitGatewayRoute
+    DependsOn: TransitGatewayAttachmentCiap
+    Properties:
+      Blackhole: False
+      DestinationCidrBlock: !Ref VPCCiapCIDR
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentCiap
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1Route2CiapBrowsing:
+    Type: AWS::EC2::TransitGatewayRoute
+    DependsOn: TransitGatewayAttachmentCiapBrowsing
+    Properties:
+      Blackhole: False
+      DestinationCidrBlock: !Ref VPCCiapBrowsingCIDR
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentCiapBrowsing
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1Route2Admin:
+    Type: AWS::EC2::TransitGatewayRoute
+    DependsOn: TransitGatewayAttachmentAdmin
+    Properties:
+      Blackhole: False
+      DestinationCidrBlock: !Ref VPCAdminCIDR
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentAdmin
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1Route2Tech:
+    Type: AWS::EC2::TransitGatewayRoute
+    DependsOn: TransitGatewayAttachmentTech
+    Properties:
+      Blackhole: False
+      DestinationCidrBlock: !Ref VPCTechCIDR
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentTech
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1Route2Project:
+    Type: AWS::EC2::TransitGatewayRoute
+    DependsOn: TransitGatewayAttachmentProject
+    Properties:
+      Blackhole: False
+      DestinationCidrBlock: !Ref VPCProjectCIDR
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentProject
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1RTAttachmentCiap:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    DependsOn: TransitGatewayAttachmentCiap
+    Properties:
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentCiap
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1RTAttachmentCiapBrowsing:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    DependsOn: TransitGatewayAttachmentCiapBrowsing
+    Properties:
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentCiapBrowsing
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1RTAttachmentAdmin:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    DependsOn: TransitGatewayAttachmentAdmin
+    Properties:
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentAdmin
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1RTAttachmentTech:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    DependsOn: TransitGatewayAttachmentTech
+    Properties:
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentTech
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
+  TransitGateway1RTAttachmentProject:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    DependsOn: TransitGatewayAttachmentProject
+    Properties:
+      TransitGatewayAttachmentId: !Ref TransitGatewayAttachmentProject
+      TransitGatewayRouteTableId: !Ref TransitGateway1RouteTable
+
   TransitGatewayAttachmentCiap:
     Type: AWS::EC2::TransitGatewayAttachment
     Properties:
@@ -1044,7 +1013,7 @@ Resources:
 {% endfor %}
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-ADMIN']]
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-CIAP']]
       TransitGatewayId: !Ref TransitGateway1
       VpcId: !Ref VPCCiap
 

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/network.yaml.j2
@@ -1,33 +1,27 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   This template creates a Multi-AZ, multi-VPC and multi-subnet infrastructure.
-  It contains definitions for core infrastructure:
-    VPCs: CIAP, Admin and Tech
-    Network elements: subnets, routing, internet gateways
-  **WARNING** This template creates AWS resources. You will be billed for the AWS
-  resources used if you create a stack from this template. QS(0027)
 
 Parameters:
   NumberOfAZs:
     AllowedValues:
-    - '2'
-    - '3'
-    - '4'
-    Default: '2'
-    Description: Number of Availability Zones to use in the VPC. This must match your
-      selections in the list of Availability Zones parameter.
+    - 2
+    - 3
+    - 4
+    Default: 2
+    Description: .
     Type: String
   DeployWAFResources:
     Default: true
-    Description: Deploy NAT resources or not
+    Description: .
     Type: String
   DeployNATResources:
     Default: true
-    Description: Deploy NAT resources or not
+    Description: .
     Type: String
   DeployVPNResources:
     Default: true
-    Description: Deploy VPN resources or not
+    Description: .
     Type: String
   VPCCiapCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -46,7 +40,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.{{ ( idx - 1 ) * 4 + 1 }}.0/24
-    Description: CIDR block for Browsing subnet {{ idx }}A located in Availability Zone {{ idx }}
+    Description: CIDR block for Browsing subnet public {{ idx }}A located in Availability Zone {{ idx }}
     Type: String
   CiapVPNSubNet{{ idx }}CIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -55,6 +49,19 @@ Parameters:
     Description: CIDR block for VPN subnet {{ idx }}A located in Availability Zone {{ idx }}
     Type: String
 {% endfor %}
+  VPCCiapBrowsingCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.48.0/20
+    Description: CIDR block for the CIAP Browsing VPC
+    Type: String
+  VPCCiapBrowsingSubnetBits:
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27.
+    MinValue: 5
+    MaxValue: 13
+    Default: 5
+    Description: "Size of each subnet to create within the availability zones. (Min: 5 = /27, Max: 13 = /19)"
+    Type: Number
   VPCAdminCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
@@ -115,7 +122,8 @@ Conditions:
   NVirginiaRegionCondition: !Equals [!Ref 'AWS::Region', us-east-1]
 
 Resources:
-  ### VPC CIAP
+
+  ### VPC CIAP - Hosting
   VPCCiapDHCPOptions:
     Type: AWS::EC2::DHCPOptions
     Properties:
@@ -128,17 +136,17 @@ Resources:
   VPCCiap:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Ref 'VPCCiapCIDR'
-      EnableDnsSupport: 'true'
-      EnableDnsHostnames: 'true'
+      CidrBlock: !Ref VPCCiapCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'VPC-Ciap']]
   VPCCiapDHCPOptionsAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
-      VpcId: !Ref 'VPCCiap'
-      DhcpOptionsId: !Ref 'VPCCiapDHCPOptions'
+      VpcId: !Ref VPCCiap
+      DhcpOptionsId: !Ref VPCCiapDHCPOptions
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
@@ -150,12 +158,12 @@ Resources:
   VPCCiapGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
-      VpcId: !Ref 'VPCCiap'
-      InternetGatewayId: !Ref 'InternetGateway'
+      VpcId: !Ref VPCCiap
+      InternetGatewayId: !Ref InternetGateway
   CiapRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref 'VPCCiap'
+      VpcId: !Ref VPCCiap
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-RouteTable']]
@@ -164,36 +172,43 @@ Resources:
   CiapRouteDefault:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: !Ref 'CiapRouteTable'
+      RouteTableId: !Ref CiapRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
   CiapRoute2Admin:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2AdminPeeringConnection
     Properties:
-      RouteTableId: !Ref 'CiapRouteTable'
+      RouteTableId: !Ref CiapRouteTable
       DestinationCidrBlock: !Ref VPCAdminCIDR
       VpcPeeringConnectionId: !Ref VPCCiap2AdminPeeringConnection
+  CiapRoute2Browsing:
+    Type: AWS::EC2::Route
+    DependsOn: TransitGatewayAttachmentCiap
+    Properties:
+      RouteTableId: !Ref CiapRouteTable
+      DestinationCidrBlock: 10.0.48.0/20
+      TransitGatewayId: !Ref TransitGateway1
   CiapRoute2Tech:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2TechPeeringConnection
     Properties:
-      RouteTableId: !Ref 'CiapRouteTable'
+      RouteTableId: !Ref CiapRouteTable
       DestinationCidrBlock: !Ref VPCTechCIDR
       VpcPeeringConnectionId: !Ref VPCCiap2TechPeeringConnection
   CiapRoute2Project:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'CiapRouteTable'
+      RouteTableId: !Ref CiapRouteTable
       DestinationCidrBlock: !Ref VPCProjectCIDR
       VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
 {% for idx in range(1, ciap_nb_subnets|int + 1) %}
   CiapHostingSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref 'VPCCiap'
-      CidrBlock: !Ref 'CiapHostingSubNet{{ idx }}CIDR'
+      VpcId: !Ref VPCCiap
+      CidrBlock: !Ref CiapHostingSubNet{{ idx }}CIDR
       AvailabilityZone:
         Fn::Select:
           - {{ idx - 1 }}
@@ -206,13 +221,13 @@ Resources:
   CiapHostingSubNet{{ idx }}RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'CiapHostingSubNet{{ idx }}'
-      RouteTableId: !Ref 'CiapRouteTable'
+      SubnetId: !Ref CiapHostingSubNet{{ idx }}
+      RouteTableId: !Ref CiapRouteTable
   CiapBrowsingSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref 'VPCCiap'
-      CidrBlock: !Ref 'CiapBrowsingSubNet{{ idx }}CIDR'
+      VpcId: !Ref VPCCiap
+      CidrBlock: !Ref CiapBrowsingSubNet{{ idx }}CIDR
       AvailabilityZone:
         Fn::Select:
           - {{ idx - 1 }}
@@ -225,14 +240,14 @@ Resources:
   CiapBrowsingSubNet{{ idx }}RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'CiapBrowsingSubNet{{ idx }}'
-      RouteTableId: !Ref 'CiapRouteTable'
+      SubnetId: !Ref CiapBrowsingSubNet{{ idx }}
+      RouteTableId: !Ref CiapRouteTable
   CiapVPNSubNet{{ idx }}:
     Condition: VPNInstanceCondition
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref 'VPCCiap'
-      CidrBlock: !Ref 'CiapVPNSubNet{{ idx }}CIDR'
+      VpcId: !Ref VPCCiap
+      CidrBlock: !Ref CiapVPNSubNet{{ idx }}CIDR
       AvailabilityZone:
         Fn::Select:
           - {{ idx - 1 }}
@@ -245,8 +260,8 @@ Resources:
   CiapVPNSubNet{{ idx }}RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'CiapVPNSubNet{{ idx }}'
-      RouteTableId: !Ref 'CiapRouteTable'
+      SubnetId: !Ref CiapVPNSubNet{{ idx }}
+      RouteTableId: !Ref CiapRouteTable
 {% endfor %}
   VPCCiap2AdminPeeringConnection:
     Type: AWS::EC2::VPCPeeringConnection
@@ -282,13 +297,13 @@ Resources:
     Type: AWS::EC2::VPCEndpoint
     Properties:
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
         - Sid: Allow access to AMZN Linux repo
           Principal: '*'
           Action:
-            - 's3:List*'
-            - 's3:Get*'
+            - s3:List*
+            - s3:Get*
           Effect: Allow
           Resource:
             - !Join ['', ['arn:aws:s3:::repo.eu-west-1.amazonaws.com']]
@@ -296,10 +311,10 @@ Resources:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
           Action:
-            - 's3:CreateBucket'
-            - 's3:List*'
-            - 's3:Get*'
-            - 's3:Put*'
+            - s3:CreateBucket
+            - s3:List*
+            - s3:Get*
+            - s3:Put*
           Effect: Allow
           Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
@@ -311,13 +326,311 @@ Resources:
         - Sid: Allow listing buckets (required by ansible s3_bucket module)
           Principal: '*'
           Action:
-            - 's3:ListAllMyBuckets'
+            - s3:ListAllMyBuckets
           Effect: Allow
           Resource: '*'
       RouteTableIds:
-      - !Ref 'CiapRouteTable'
+      - !Ref CiapRouteTable
       ServiceName: !Join ['', [com.amazonaws., !Ref 'AWS::Region', .s3]]
-      VpcId: !Ref 'VPCCiap'
+      VpcId: !Ref VPCCiap
+
+
+  ### VPC CIAP - Browsing
+  VPCCiapBrowsing:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VPCCiapBrowsingCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'VPC-CiapBrowsing']]
+
+  # Public subnets
+  CiapBrowsingPublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      CidrBlock: !Select [0, !Cidr [!Ref VPCCiapBrowsingCIDR, 6, !Ref VPCCiapBrowsingSubnetBits]]
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref AWS::Region
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-Browsing-Public-subnet-1']]
+      - Key: Network
+        Value: CIAP_Browsing_Public
+
+  CiapBrowsingPublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Condition: 2AZCondition
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      CidrBlock: !Select [1, !Cidr [!Ref VPCCiapBrowsingCIDR, 6, !Ref VPCCiapBrowsingSubnetBits]]
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref AWS::Region
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-Browsing-Public-subnet-2']]
+      - Key: Network
+        Value: CIAP_Browsing_Public
+
+  CiapBrowsingPublicSubnet3:
+    Type: AWS::EC2::Subnet
+    Condition: 3AZCondition
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      CidrBlock: !Select [2, !Cidr [!Ref VPCCiapBrowsingCIDR, 6, !Ref VPCCiapBrowsingSubnetBits]]
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref AWS::Region
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-Browsing-Public-subnet-3']]
+      - Key: Network
+        Value: CIAP_Browsing_Public
+
+  CiapBrowsingPublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAPBrowsing-PublicRouteTable']]
+      - Key: Network
+        Value: CIAP_Browsing_Public
+
+  CiapBrowsingPublicSubNetRouteTableAssociation1:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref CiapBrowsingPublicSubnet1
+      RouteTableId: !Ref CiapBrowsingPublicRouteTable
+
+  CiapBrowsingPublicSubNetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: 2AZCondition
+    Properties:
+      SubnetId: !Ref CiapBrowsingPublicSubnet2
+      RouteTableId: !Ref CiapBrowsingPublicRouteTable
+
+  CiapBrowsingPublicSubNetRouteTableAssociation3:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: 3AZCondition
+    Properties:
+      SubnetId: !Ref CiapBrowsingPublicSubnet3
+      RouteTableId: !Ref CiapBrowsingPublicRouteTable
+
+  # Private subnets
+  CiapBrowsingPrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      CidrBlock: !Select [3, !Cidr [!Ref VPCCiapBrowsingCIDR, 6, !Ref VPCCiapBrowsingSubnetBits]]
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref AWS::Region
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-Browsing-Private-subnet-1']]
+      - Key: Network
+        Value: CIAP_Browsing_Private
+
+  CiapBrowsingPrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Condition: 2AZCondition
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      CidrBlock: !Select [4, !Cidr [!Ref VPCCiapBrowsingCIDR, 6, !Ref VPCCiapBrowsingSubnetBits]]
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref AWS::Region
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-Browsing-Private-subnet-2']]
+      - Key: Network
+        Value: CIAP_Browsing_Private
+
+  CiapBrowsingPrivateSubnet3:
+    Type: AWS::EC2::Subnet
+    Condition: 3AZCondition
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      CidrBlock: !Select [5, !Cidr [!Ref VPCCiapBrowsingCIDR, 6, !Ref VPCCiapBrowsingSubnetBits]]
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref AWS::Region
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-Browsing-Private-subnet-3']]
+      - Key: Network
+        Value: CIAP_Browsing_Private
+
+  CiapBrowsingPrivateRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAPBrowsing-PrivateRouteTable1']]
+      - Key: Network
+        Value: CIAP_Browsing_Private1
+
+  CiapBrowsingPrivateRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Condition: 2AZCondition
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAPBrowsing-PrivateRouteTable2']]
+      - Key: Network
+        Value: CIAP_Browsing_Private2
+
+  CiapBrowsingPrivateRouteTable3:
+    Type: AWS::EC2::RouteTable
+    Condition: 3AZCondition
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAPBrowsing-PrivateRouteTable3']]
+      - Key: Network
+        Value: CIAP_Browsing_Private3
+
+  CiapBrowsingPrivateSubNetRouteTableAssociation1:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref CiapBrowsingPrivateSubnet1
+      RouteTableId: !Ref CiapBrowsingPrivateRouteTable1
+
+  CiapBrowsingPrivateSubNetRouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: 2AZCondition
+    Properties:
+      SubnetId: !Ref CiapBrowsingPrivateSubnet2
+      RouteTableId: !Ref CiapBrowsingPrivateRouteTable2
+
+  CiapBrowsingPrivateSubNetRouteTableAssociation3:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: 3AZCondition
+    Properties:
+      SubnetId: !Ref CiapBrowsingPrivateSubnet3
+      RouteTableId: !Ref CiapBrowsingPrivateRouteTable3
+
+  CiapBrowsingPrivateRoute1TGW:
+    Type: AWS::EC2::Route
+    DependsOn: TransitGateway1
+    Properties:
+      RouteTableId: !Ref CiapBrowsingPrivateRouteTable1
+      DestinationCidrBlock: 10.0.0.0/8
+      TransitGatewayId: !Ref TransitGateway1
+
+  CiapBrowsingPrivateRoute2TGW:
+    Type: AWS::EC2::Route
+    Condition: 2AZCondition
+    DependsOn: TransitGateway1
+    Properties:
+      RouteTableId: !Ref CiapBrowsingPrivateRouteTable2
+      DestinationCidrBlock: 10.0.0.0/8
+      TransitGatewayId: !Ref TransitGateway1
+
+  CiapBrowsingPrivateRoute3TGW:
+    Type: AWS::EC2::Route
+    Condition: 3AZCondition
+    DependsOn: TransitGateway1
+    Properties:
+      RouteTableId: !Ref CiapBrowsingPrivateRouteTable3
+      DestinationCidrBlock: 10.0.0.0/8
+      TransitGatewayId: !Ref TransitGateway1
+
+  CiapBrowsingPublicRouteTableDefault:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref CiapBrowsingPublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGatewayBrowsing
+
+  CiapBrowsingPublicRouteTGW:
+    Type: AWS::EC2::Route
+    DependsOn: TransitGateway1
+    Properties:
+      RouteTableId: !Ref CiapBrowsingPublicRouteTable
+      DestinationCidrBlock: 10.0.0.0/8
+      TransitGatewayId: !Ref TransitGateway1
+
+  VPCCiapBrowsingDHCPOptions:
+    Type: AWS::EC2::DHCPOptions
+    Properties:
+      DomainName: {{ private_dns_domain }}
+      DomainNameServers:
+      - AmazonProvidedDNS
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'VPC-CiapBrowsing']]
+
+  VPCCiapBrowsingDHCPOptionsAssociation:
+    Type: AWS::EC2::VPCDHCPOptionsAssociation
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      DhcpOptionsId: !Ref VPCCiapBrowsingDHCPOptions
+
+  InternetGatewayBrowsing:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'IGWBrowsing']]
+      - Key: Network
+        Value: Public
+
+  VPCCiapBrowsingGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPCCiapBrowsing
+      InternetGatewayId: !Ref InternetGatewayBrowsing
+
+  VPCCiapBrowsingS3VPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Sid: Allow access to AMZN Linux repo
+          Principal: '*'
+          Action:
+            - s3:List*
+            - s3:Get*
+          Effect: Allow
+          Resource:
+            - !Join ['', ['arn:aws:s3:::repo.eu-west-1.amazonaws.com']]
+            - !Join ['', ['arn:aws:s3:::repo.eu-west-1.amazonaws.com/*']]
+        - Sid: Allow access only to current stack buckets
+          Principal: '*'
+          Action:
+            - s3:CreateBucket
+            - s3:List*
+            - s3:Get*
+            - s3:Put*
+          Effect: Allow
+          Resource:
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*/*']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-data/*']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs']]
+            - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs/*']]
+        - Sid: Allow listing buckets (required by ansible s3_bucket module)
+          Principal: '*'
+          Action:
+            - s3:ListAllMyBuckets
+          Effect: Allow
+          Resource: '*'
+      RouteTableIds:
+      - !Ref CiapBrowsingPublicRouteTable
+      ServiceName: !Join ['', [com.amazonaws., !Ref 'AWS::Region', .s3]]
+      VpcId: !Ref VPCCiapBrowsing
+
   ### VPC Admin
   VPCAdminDHCPOptions:
     Type: AWS::EC2::DHCPOptions
@@ -331,21 +644,21 @@ Resources:
   VPCAdmin:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Ref 'VPCAdminCIDR'
-      EnableDnsSupport: 'true'
-      EnableDnsHostnames: 'true'
+      CidrBlock: !Ref VPCAdminCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'VPC-Admin']]
   VPCAdminDHCPOptionsAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
-      VpcId: !Ref 'VPCAdmin'
-      DhcpOptionsId: !Ref 'VPCAdminDHCPOptions'
+      VpcId: !Ref VPCAdmin
+      DhcpOptionsId: !Ref VPCAdminDHCPOptions
   AdminRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref 'VPCAdmin'
+      VpcId: !Ref VPCAdmin
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Admin-RouteTable']]
@@ -355,29 +668,29 @@ Resources:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2AdminPeeringConnection
     Properties:
-      RouteTableId: !Ref 'AdminRouteTable'
+      RouteTableId: !Ref AdminRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       VpcPeeringConnectionId: !Ref VPCCiap2AdminPeeringConnection
   AdminRoute2Tech:
     Type: AWS::EC2::Route
     DependsOn: VPCAdmin2TechPeeringConnection
     Properties:
-      RouteTableId: !Ref 'AdminRouteTable'
+      RouteTableId: !Ref AdminRouteTable
       DestinationCidrBlock: !Ref VPCTechCIDR
       VpcPeeringConnectionId: !Ref VPCAdmin2TechPeeringConnection
   AdminRoute2Project:
     Type: AWS::EC2::Route
     DependsOn: VPCAdmin2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'AdminRouteTable'
+      RouteTableId: !Ref AdminRouteTable
       DestinationCidrBlock: !Ref VPCProjectCIDR
       VpcPeeringConnectionId: !Ref VPCAdmin2ProjectPeeringConnection
 {% for idx in range(1, admin_nb_subnets|int + 1) %}
   AdminSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref 'VPCAdmin'
-      CidrBlock: !Ref 'AdminSubNet{{ idx }}CIDR'
+      VpcId: !Ref VPCAdmin
+      CidrBlock: !Ref AdminSubNet{{ idx }}CIDR
       AvailabilityZone:
         Fn::Select:
           - {{ idx - 1 }}
@@ -390,8 +703,8 @@ Resources:
   AdminSubNet{{ idx }}RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'AdminSubNet{{ idx }}'
-      RouteTableId: !Ref 'AdminRouteTable'
+      SubnetId: !Ref AdminSubNet{{ idx }}
+      RouteTableId: !Ref AdminRouteTable
 {% endfor %}
   VPCAdmin2TechPeeringConnection:
     Type: AWS::EC2::VPCPeeringConnection
@@ -417,15 +730,15 @@ Resources:
     Type: AWS::EC2::VPCEndpoint
     Properties:
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
           Action:
-            - 's3:CreateBucket'
-            - 's3:List*'
-            - 's3:Get*'
-            - 's3:Put*'
+            - s3:CreateBucket
+            - s3:List*
+            - s3:Get*
+            - s3:Put*
           Effect: Allow
           Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
@@ -435,9 +748,9 @@ Resources:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs/*']]
       RouteTableIds:
-      - !Ref 'AdminRouteTable'
+      - !Ref AdminRouteTable
       ServiceName: !Join ['', [com.amazonaws., !Ref 'AWS::Region', .s3]]
-      VpcId: !Ref 'VPCAdmin'
+      VpcId: !Ref VPCAdmin
   ### VPC Tech
   VPCTechDHCPOptions:
     Type: AWS::EC2::DHCPOptions
@@ -451,21 +764,21 @@ Resources:
   VPCTech:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Ref 'VPCTechCIDR'
-      EnableDnsSupport: 'true'
-      EnableDnsHostnames: 'true'
+      CidrBlock: !Ref VPCTechCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'VPC-Tech']]
   VPCTechDHCPOptionsAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
-      VpcId: !Ref 'VPCTech'
-      DhcpOptionsId: !Ref 'VPCTechDHCPOptions'
+      VpcId: !Ref VPCTech
+      DhcpOptionsId: !Ref VPCTechDHCPOptions
   TechRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref 'VPCTech'
+      VpcId: !Ref VPCTech
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Tech-RouteTable']]
@@ -475,29 +788,29 @@ Resources:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2TechPeeringConnection
     Properties:
-      RouteTableId: !Ref 'TechRouteTable'
+      RouteTableId: !Ref TechRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       VpcPeeringConnectionId: !Ref VPCCiap2TechPeeringConnection
   TechRoute2Admin:
     Type: AWS::EC2::Route
     DependsOn: VPCAdmin2TechPeeringConnection
     Properties:
-      RouteTableId: !Ref 'TechRouteTable'
+      RouteTableId: !Ref TechRouteTable
       DestinationCidrBlock: !Ref VPCAdminCIDR
       VpcPeeringConnectionId: !Ref VPCAdmin2TechPeeringConnection
   TechRoute2Project:
     Type: AWS::EC2::Route
     DependsOn: VPCTech2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'TechRouteTable'
+      RouteTableId: !Ref TechRouteTable
       DestinationCidrBlock: !Ref VPCProjectCIDR
       VpcPeeringConnectionId: !Ref VPCTech2ProjectPeeringConnection
 {% for idx in range(1, tech_nb_subnets|int + 1) %}
   TechSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref 'VPCTech'
-      CidrBlock: !Ref 'TechSubNet{{ idx }}CIDR'
+      VpcId: !Ref VPCTech
+      CidrBlock: !Ref TechSubNet{{ idx }}CIDR
       AvailabilityZone:
         Fn::Select:
           - {{ idx - 1 }}
@@ -510,8 +823,8 @@ Resources:
   TechSubNet{{ idx }}RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'TechSubNet{{ idx }}'
-      RouteTableId: !Ref 'TechRouteTable'
+      SubnetId: !Ref TechSubNet{{ idx }}
+      RouteTableId: !Ref TechRouteTable
 {% endfor %}
   VPCTech2ProjectPeeringConnection:
     Type: AWS::EC2::VPCPeeringConnection
@@ -527,15 +840,15 @@ Resources:
     Type: AWS::EC2::VPCEndpoint
     Properties:
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
           Action:
-            - 's3:CreateBucket'
-            - 's3:List*'
-            - 's3:Get*'
-            - 's3:Put*'
+            - s3:CreateBucket
+            - s3:List*
+            - s3:Get*
+            - s3:Put*
           Effect: Allow
           Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
@@ -545,9 +858,9 @@ Resources:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs/*']]
       RouteTableIds:
-      - !Ref 'TechRouteTable'
+      - !Ref TechRouteTable
       ServiceName: !Join ['', [com.amazonaws., !Ref 'AWS::Region', .s3]]
-      VpcId: !Ref 'VPCTech'
+      VpcId: !Ref VPCTech
   ### VPC Project
   VPCProjectDHCPOptions:
     Type: AWS::EC2::DHCPOptions
@@ -562,21 +875,21 @@ Resources:
   VPCProject:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Ref 'VPCProjectCIDR'
-      EnableDnsSupport: 'true'
-      EnableDnsHostnames: 'true'
+      CidrBlock: !Ref VPCProjectCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'VPC-Project']]
   VPCProjectDHCPOptionsAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
-      VpcId: !Ref 'VPCProject'
-      DhcpOptionsId: !Ref 'VPCProjectDHCPOptions'
+      VpcId: !Ref VPCProject
+      DhcpOptionsId: !Ref VPCProjectDHCPOptions
   ProjectRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref 'VPCProject'
+      VpcId: !Ref VPCProject
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Project-RouteTable']]
@@ -586,8 +899,8 @@ Resources:
   ProjectSubNet{{ idx }}:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref 'VPCProject'
-      CidrBlock: !Ref 'ProjectSubNet{{ idx }}CIDR'
+      VpcId: !Ref VPCProject
+      CidrBlock: !Ref ProjectSubNet{{ idx }}CIDR
       AvailabilityZone:
         Fn::Select:
           - {{ idx - 1 }}
@@ -602,50 +915,50 @@ Resources:
   ProjectSubNet{{ idx }}RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'ProjectSubNet{{ idx }}'
-      RouteTableId: !Ref 'ProjectRouteTable'
+      SubnetId: !Ref ProjectSubNet{{ idx }}
+      RouteTableId: !Ref ProjectRouteTable
 {% endfor %}
   ProjectRoute2Default:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'ProjectRouteTable'
+      RouteTableId: !Ref ProjectRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
   ProjectRoute2Ciap:
     Type: AWS::EC2::Route
     DependsOn: VPCCiap2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'ProjectRouteTable'
+      RouteTableId: !Ref ProjectRouteTable
       DestinationCidrBlock: !Ref VPCCiapCIDR
       VpcPeeringConnectionId: !Ref VPCCiap2ProjectPeeringConnection
   ProjectRoute2Admin:
     Type: AWS::EC2::Route
     DependsOn: VPCAdmin2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'ProjectRouteTable'
+      RouteTableId: !Ref ProjectRouteTable
       DestinationCidrBlock: !Ref VPCAdminCIDR
       VpcPeeringConnectionId: !Ref VPCAdmin2ProjectPeeringConnection
   ProjectRoute2Tech:
     Type: AWS::EC2::Route
     DependsOn: VPCTech2ProjectPeeringConnection
     Properties:
-      RouteTableId: !Ref 'ProjectRouteTable'
+      RouteTableId: !Ref ProjectRouteTable
       DestinationCidrBlock: !Ref VPCTechCIDR
       VpcPeeringConnectionId: !Ref VPCTech2ProjectPeeringConnection
   VPCProjectS3VPCEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
         - Sid: Allow access only to current stack buckets
           Principal: '*'
           Action:
-            - 's3:CreateBucket'
-            - 's3:List*'
-            - 's3:Get*'
-            - 's3:Put*'
+            - s3:CreateBucket
+            - s3:List*
+            - s3:Get*
+            - s3:Put*
           Effect: Allow
           Resource:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-*']]
@@ -655,189 +968,308 @@ Resources:
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs']]
             - !Join ['', ['arn:aws:s3:::', !Ref S3BucketPrefix, '-logs/*']]
       RouteTableIds:
-      - !Ref 'ProjectRouteTable'
+      - !Ref ProjectRouteTable
       ServiceName: !Join ['', [com.amazonaws., !Ref 'AWS::Region', .s3]]
-      VpcId: !Ref 'VPCProject'
+      VpcId: !Ref VPCProject
 
   ### DNS
   ### Public zones are created by Ansible because they may need to persist when stack is deleted...
   DNSPrivateZone:
-    Type: "AWS::Route53::HostedZone"
+    Type: AWS::Route53::HostedZone
     Properties:
       HostedZoneConfig:
         Comment: !Join ['', ['Private DNS Domain Name for stack ', !Ref 'AWS::StackName']]
       Name: !Ref PrivateDNSDomain
       VPCs:
         -
-          VPCId: !Ref 'VPCCiap'
-          VPCRegion: !Ref 'AWS::Region'
+          VPCId: !Ref VPCCiap
+          VPCRegion: !Ref AWS::Region
         -
-          VPCId: !Ref 'VPCAdmin'
-          VPCRegion: !Ref 'AWS::Region'
+          VPCId: !Ref VPCCiapBrowsing
+          VPCRegion: !Ref AWS::Region
         -
-          VPCId: !Ref 'VPCTech'
-          VPCRegion: !Ref 'AWS::Region'
+          VPCId: !Ref VPCAdmin
+          VPCRegion: !Ref AWS::Region
         -
-          VPCId: !Ref 'VPCProject'
-          VPCRegion: !Ref 'AWS::Region'
+          VPCId: !Ref VPCTech
+          VPCRegion: !Ref AWS::Region
+        -
+          VPCId: !Ref VPCProject
+          VPCRegion: !Ref AWS::Region
       HostedZoneTags:
         -
-          Key: "DomainName"
+          Key: DomainName
           Value: !Ref PrivateDNSDomain
+
+  TransitGateway1:
+    Type: AWS::EC2::TransitGateway
+    Properties:
+      AmazonSideAsn: 65000
+      Description: Transit Gateway for stack {{stack_name}}
+      AutoAcceptSharedAttachments: enable
+      DefaultRouteTableAssociation: enable
+      DnsSupport: enable
+      VpnEcmpSupport: enable
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW']]
+
+  TransitGatewayAttachmentCiapBrowsing:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds:
+        - !Ref CiapBrowsingPrivateSubnet1
+        - 'Fn::If':
+          - 2AZCondition
+          -
+            !Ref CiapBrowsingPrivateSubnet2
+          - !Ref "AWS::NoValue"
+        - 'Fn::If':
+          - 3AZCondition
+          -
+            !Ref CiapBrowsingPrivateSubnet3
+          - !Ref "AWS::NoValue"
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-CIAPBrowsing']]
+      TransitGatewayId: !Ref TransitGateway1
+      VpcId: !Ref VPCCiapBrowsing
+
+  TransitGatewayAttachmentCiap:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds:
+{% for idx in range(1, ciap_nb_subnets|int + 1) %}
+        - !Ref CiapHostingSubNet{{ idx }}
+{% endfor %}
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-ADMIN']]
+      TransitGatewayId: !Ref TransitGateway1
+      VpcId: !Ref VPCCiap
+
+  TransitGatewayAttachmentAdmin:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds:
+{% for idx in range(1, admin_nb_subnets|int + 1) %}
+        - !Ref AdminSubNet{{ idx }}
+{% endfor %}
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-ADMIN']]
+      TransitGatewayId: !Ref TransitGateway1
+      VpcId: !Ref VPCAdmin
+
+  TransitGatewayAttachmentTech:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds:
+{% for idx in range(1, tech_nb_subnets|int + 1) %}
+        - !Ref TechSubNet{{ idx }}
+{% endfor %}
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-TECH']]
+      TransitGatewayId: !Ref TransitGateway1
+      VpcId: !Ref VPCTech
+
+  TransitGatewayAttachmentProject:
+    Type: AWS::EC2::TransitGatewayAttachment
+    Properties:
+      SubnetIds:
+{% for idx in range(1, project_nb_subnets|int + 1) %}
+        - !Ref ProjectSubNet{{ idx }}
+{% endfor %}
+      Tags:
+        - Key: Name
+          Value: !Join ['-', [!Ref 'AWS::StackName', 'TGW-Att-PROJECT']]
+      TransitGatewayId: !Ref TransitGateway1
+      VpcId: !Ref VPCProject
+
+
 
 Outputs:
   VPCCiapCIDR:
-    Value: !Ref 'VPCCiapCIDR'
+    Value: !Ref VPCCiapCIDR
     Description: VPC CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-VPCCiapCIDR'
+      Name: !Sub ${AWS::StackName}-VPCCiapCIDR
   VPCCiapID:
-    Value: !Ref 'VPCCiap'
+    Value: !Ref VPCCiap
     Description: VPC ID
     Export:
-      Name: !Sub '${AWS::StackName}-VPCCiapID'
+      Name: !Sub ${AWS::StackName}-VPCCiapID
   CiapRouteTableID:
-    Value: !Ref 'CiapRouteTable'
+    Value: !Ref CiapRouteTable
     Description: CIAP route table
     Export:
-      Name: !Sub '${AWS::StackName}-CiapRouteTable'
+      Name: !Sub ${AWS::StackName}-CiapRouteTable
 {% for idx in range(1, ciap_nb_subnets|int + 1) %}
   CiapHostingSubNet{{ idx }}CIDR:
     Description: CIAP Hosting subnet 1 CIDR in Availability Zone {{ idx }}
-    Value: !Ref 'CiapHostingSubNet{{ idx }}CIDR'
+    Value: !Ref CiapHostingSubNet{{ idx }}CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-CiapHostingSubNet{{ idx }}CIDR'
+      Name: !Sub ${AWS::StackName}-CiapHostingSubNet{{ idx }}CIDR
   CiapHostingSubNet{{ idx }}ID:
     Description: CIAP Hosting subnet 1 ID in Availability Zone {{ idx }}
-    Value: !Ref 'CiapHostingSubNet{{ idx }}'
+    Value: !Ref CiapHostingSubNet{{ idx }}
     Export:
-      Name: !Sub '${AWS::StackName}-CiapHostingSubNet{{ idx }}ID'
+      Name: !Sub ${AWS::StackName}-CiapHostingSubNet{{ idx }}ID
   CiapBrowsingSubNet{{ idx }}CIDR:
     Description: CIAP Browsing subnet 1 CIDR in Availability Zone {{ idx }}
-    Value: !Ref 'CiapBrowsingSubNet{{ idx }}CIDR'
+    Value: !Ref CiapBrowsingSubNet{{ idx }}CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-CiapBrowsingSubNet{{ idx }}CIDR'
+      Name: !Sub ${AWS::StackName}-CiapBrowsingSubNet{{ idx }}CIDR
   CiapBrowsingSubNet{{ idx }}ID:
     Description: CIAP Browsing subnet 1 ID in Availability Zone {{ idx }}
-    Value: !Ref 'CiapBrowsingSubNet{{ idx }}'
+    Value: !Ref CiapBrowsingSubNet{{ idx }}
     Export:
-      Name: !Sub '${AWS::StackName}-CiapBrowsingSubNet{{ idx }}ID'
+      Name: !Sub ${AWS::StackName}-CiapBrowsingSubNet{{ idx }}ID
   CiapVPNSubNet{{ idx }}CIDR:
     Condition: VPNInstanceCondition
     Description: CIAP VPN subnet 1 CIDR in Availability Zone {{ idx }}
-    Value: !Ref 'CiapVPNSubNet{{ idx }}CIDR'
+    Value: !Ref CiapVPNSubNet{{ idx }}CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-CiapVPNSubNet{{ idx }}CIDR'
+      Name: !Sub ${AWS::StackName}-CiapVPNSubNet{{ idx }}CIDR
   CiapVPNSubNet{{ idx }}ID:
     Condition: VPNInstanceCondition
     Description: CIAP VPN subnet 1 ID in Availability Zone {{ idx }}
-    Value: !Ref 'CiapVPNSubNet{{ idx }}'
+    Value: !Ref CiapVPNSubNet{{ idx }}
     Export:
-      Name: !Sub '${AWS::StackName}-CiapVPNSubNet{{ idx }}ID'
+      Name: !Sub ${AWS::StackName}-CiapVPNSubNet{{ idx }}ID
+{% endfor %}
+  # CiapBrowsing
+  VPCCiapBrowsingID:
+    Value: !Ref VPCCiapBrowsing
+    Description: VPC CIAPBrowsing ID
+    Export:
+      Name: !Sub ${AWS::StackName}-VPCCiapBrowsingID
+  CiapBrowsingPublicRouteTableID:
+    Value: !Ref CiapBrowsingPublicRouteTable
+    Description: CIAP Browsing Public route table
+    Export:
+      Name: !Sub ${AWS::StackName}-CiapBrowsingPublicRouteTable
+{% for idx in range(1, ciap_nb_subnets|int + 1) %}
+  CiapBrowsingPrivateRouteTable{{ idx }}ID:
+    Value: !Ref CiapBrowsingPrivateRouteTable{{ idx }}
+    Description: CIAP Browsing Private route table {{ idx }}
+    Export:
+      Name: !Sub ${AWS::StackName}-CiapBrowsingPrivateRouteTable{{ idx }}
+  CiapBrowsingPublicSubnet{{ idx }}ID:
+    Description: CIAP Browsing Public subnet ID in Availability Zone {{ idx }}
+    Value: !Ref CiapBrowsingPublicSubnet{{ idx }}
+    Export:
+      Name: !Sub ${AWS::StackName}-CiapBrowsingPublicSubnet{{ idx }}ID
+  CiapBrowsingPrivateSubnet{{ idx }}ID:
+    Description: CIAP Browsing Private subnet ID in Availability Zone {{ idx }}
+    Value: !Ref CiapBrowsingPrivateSubnet{{ idx }}
+    Export:
+      Name: !Sub ${AWS::StackName}-CiapBrowsingPrivateSubnet{{ idx }}ID
 {% endfor %}
   VPCAdminCIDR:
-    Value: !Ref 'VPCAdminCIDR'
+    Value: !Ref VPCAdminCIDR
     Description: Admin VPC CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-VPCAdminCIDR'
+      Name: !Sub ${AWS::StackName}-VPCAdminCIDR
   VPCAdminID:
-    Value: !Ref 'VPCAdmin'
+    Value: !Ref VPCAdmin
     Description: Admin VPC ID
     Export:
-      Name: !Sub '${AWS::StackName}-VPCAdminID'
+      Name: !Sub ${AWS::StackName}-VPCAdminID
   AdminRouteTableID:
-    Value: !Ref 'AdminRouteTable'
+    Value: !Ref AdminRouteTable
     Description: Admin route table
     Export:
-      Name: !Sub '${AWS::StackName}-AdminRouteTable'
+      Name: !Sub ${AWS::StackName}-AdminRouteTable
 {% for idx in range(1, admin_nb_subnets|int + 1) %}
   AdminSubNet{{ idx }}CIDR:
     Description: Admin subnet 1 CIDR in Availability Zone {{ idx }}
-    Value: !Ref 'AdminSubNet{{ idx }}CIDR'
+    Value: !Ref AdminSubNet{{ idx }}CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-AdminSubNet{{ idx }}CIDR'
+      Name: !Sub ${AWS::StackName}-AdminSubNet{{ idx }}CIDR
   AdminSubNet{{ idx }}ID:
     Description: Admin subnet 1 ID in Availability Zone {{ idx }}
-    Value: !Ref 'AdminSubNet{{ idx }}'
+    Value: !Ref AdminSubNet{{ idx }}
     Export:
-      Name: !Sub '${AWS::StackName}-AdminSubNet{{ idx }}ID'
+      Name: !Sub ${AWS::StackName}-AdminSubNet{{ idx }}ID
 {% endfor %}
   VPCTechCIDR:
-    Value: !Ref 'VPCTechCIDR'
+    Value: !Ref VPCTechCIDR
     Description: Tech VPC CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-VPCTechCIDR'
+      Name: !Sub ${AWS::StackName}-VPCTechCIDR
   VPCTechID:
-    Value: !Ref 'VPCTech'
+    Value: !Ref VPCTech
     Description: Tech VPC ID
     Export:
-      Name: !Sub '${AWS::StackName}-VPCTechID'
+      Name: !Sub ${AWS::StackName}-VPCTechID
   TechRouteTableID:
-    Value: !Ref 'TechRouteTable'
+    Value: !Ref TechRouteTable
     Description: Tech route table
     Export:
-      Name: !Sub '${AWS::StackName}-TechRouteTable'
+      Name: !Sub ${AWS::StackName}-TechRouteTable
 {% for idx in range(1, tech_nb_subnets|int + 1) %}
   TechSubNet{{ idx }}CIDR:
     Description: Tech subnet 1 CIDR in Availability Zone {{ idx }}
-    Value: !Ref 'TechSubNet{{ idx }}CIDR'
+    Value: !Ref TechSubNet{{ idx }}CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-TechSubNet{{ idx }}CIDR'
+      Name: !Sub ${AWS::StackName}-TechSubNet{{ idx }}CIDR
   TechSubNet{{ idx }}ID:
     Description: Tech subnet 1 ID in Availability Zone {{ idx }}
-    Value: !Ref 'TechSubNet{{ idx }}'
+    Value: !Ref TechSubNet{{ idx }}
     Export:
-      Name: !Sub '${AWS::StackName}-TechSubNet{{ idx }}ID'
+      Name: !Sub ${AWS::StackName}-TechSubNet{{ idx }}ID
 {% endfor %}
   VPCProjectCIDR:
-    Value: !Ref 'VPCProjectCIDR'
+    Value: !Ref VPCProjectCIDR
     Description: Project VPC CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-VPCProjectCIDR'
+      Name: !Sub ${AWS::StackName}-VPCProjectCIDR
   VPCProjectID:
-    Value: !Ref 'VPCProject'
+    Value: !Ref VPCProject
     Description: Project VPC ID
     Export:
-      Name: !Sub '${AWS::StackName}-VPCProjectID'
+      Name: !Sub ${AWS::StackName}-VPCProjectID
   ProjectRouteTableID:
-    Value: !Ref 'ProjectRouteTable'
+    Value: !Ref ProjectRouteTable
     Description: Project route table
     Export:
-      Name: !Sub '${AWS::StackName}-ProjectRouteTable'
+      Name: !Sub ${AWS::StackName}-ProjectRouteTable
 {% for idx in range(1, project_nb_subnets|int + 1) %}
   ProjectSubNet{{ idx }}CIDR:
     Description: Project default ID in Availability Zone {{ idx }}
-    Value: !Ref 'ProjectSubNet{{ idx }}CIDR'
+    Value: !Ref ProjectSubNet{{ idx }}CIDR
     Export:
-      Name: !Sub '${AWS::StackName}-ProjectSubNet{{ idx }}CIDR'
+      Name: !Sub ${AWS::StackName}-ProjectSubNet{{ idx }}CIDR
   ProjectSubNet{{ idx }}ID:
     Description: Project default SubNet ID in Availability Zone {{ idx }}
-    Value: !Ref 'ProjectSubNet{{ idx }}'
+    Value: !Ref ProjectSubNet{{ idx }}
     Export:
-      Name: !Sub '${AWS::StackName}-ProjectSubNet{{ idx }}ID'
+      Name: !Sub ${AWS::StackName}-ProjectSubNet{{ idx }}ID
 {% endfor %}
   VPCCiapS3VPCEndpointID:
-    Value: !Ref 'VPCCiapS3VPCEndpoint'
+    Value: !Ref VPCCiapS3VPCEndpoint
     Description: CIAP VPC Endpoint for S3
     Export:
-      Name: !Sub '${AWS::StackName}-VPCCiapS3VPCEndpointID'
+      Name: !Sub ${AWS::StackName}-VPCCiapS3VPCEndpointID
   VPCAdminS3VPCEndpointID:
-    Value: !Ref 'VPCAdminS3VPCEndpoint'
+    Value: !Ref VPCAdminS3VPCEndpoint
     Description: Admin VPC Endpoint for S3
     Export:
-      Name: !Sub '${AWS::StackName}-VPCAdminS3VPCEndpointID'
+      Name: !Sub ${AWS::StackName}-VPCAdminS3VPCEndpointID
   VPCTechS3VPCEndpointID:
-    Value: !Ref 'VPCTechS3VPCEndpoint'
+    Value: !Ref VPCTechS3VPCEndpoint
     Description: Tech VPC Endpoint for S3
     Export:
-      Name: !Sub '${AWS::StackName}-VPCTechS3VPCEndpointID'
+      Name: !Sub ${AWS::StackName}-VPCTechS3VPCEndpointID
   VPCProjectS3VPCEndpointID:
-    Value: !Ref 'VPCProjectS3VPCEndpoint'
+    Value: !Ref VPCProjectS3VPCEndpoint
     Description: Project VPC Endpoint for S3
     Export:
-      Name: !Sub '${AWS::StackName}-VPCProjectS3VPCEndpointID'
+      Name: !Sub ${AWS::StackName}-VPCProjectS3VPCEndpointID
   DNSPrivateZoneID:
-    Value: !Ref 'DNSPrivateZone'
+    Value: !Ref DNSPrivateZone
     Description: Private DNS Zone ID
     Export:
-      Name: !Sub '${AWS::StackName}-DNSPrivateZoneID'
+      Name: !Sub ${AWS::StackName}-DNSPrivateZoneID

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/role-policy-oip-installer.json.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/role-policy-oip-installer.json.j2
@@ -27,6 +27,7 @@
       "Effect": "Allow",
       "Action": [
           "route53:AssociateVPCWithHostedZone",
+          "route53:DisassociateVPCFromHostedZone",
           "route53:Change*",
           "route53:Create*",
           "route53:Get*",

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/roles-logs-profiles.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/roles-logs-profiles.yaml.j2
@@ -787,6 +787,7 @@ Resources:
             Action:
             - ec2:DescribeInstances
             - ec2:DescribeRouteTables
+            - ec2:DescribeSubnets
             - ec2:ModifyInstanceAttribute
             Resource: '*'
       - PolicyName: EC2-CreateRoute
@@ -801,7 +802,7 @@ Resources:
             - "arn:aws:ec2:{{region}}:{{root_account['account_id']}}:route-table/*"
             Condition:
               StringEquals:
-                'ec2:vpc' : "arn:aws:ec2:{{region}}:{{root_account['account_id']}}:vpc/{{ cfnet['stack_outputs']['VPCProjectID'] }}"
+                'ec2:vpc' : "arn:aws:ec2:{{region}}:{{root_account['account_id']}}:vpc/{{ cfnet['stack_outputs']['VPCCiapBrowsingID'] }}"
 
   TPCloudWatchLogsGroup:
     Type: AWS::Logs::LogGroup

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/security-groups.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/security-groups.yaml.j2
@@ -405,7 +405,7 @@ Resources:
       - IpProtocol: tcp
         FromPort: 22
         ToPort: 22
-        DestinationSecurityGroupId: !Ref 'BastionELBSecurityGroup'
+        CidrIp: 10.0.0.0/8
       - IpProtocol: tcp
         FromPort: !Ref SquidPort
         ToPort: !Ref SquidPort

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/security-groups.yaml.j2
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/files/security-groups.yaml.j2
@@ -302,6 +302,90 @@ Resources:
       IpProtocol: tcp
       ToPort: !Ref 'SquidPort'
 
+  # NAT2
+  NAT2InstanceSecurityGroup:
+    Condition: NATInstanceCondition
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enables outbound internet access for the VPC via the NAT instances
+      VpcId:
+        Fn::ImportValue:
+          !Sub "{{ stack_name }}-net-VPCCiapBrowsingID"
+      SecurityGroupEgress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: '-1'
+        IpProtocol: '-1'
+        ToPort: '-1'
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 10.0.0.0/8
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: 10.0.0.0/8
+      - IpProtocol: tcp
+        FromPort: !Ref SquidPort
+        ToPort: !Ref SquidPort
+        CidrIp: 10.0.0.0/8
+      - IpProtocol: tcp
+        FromPort: !Ref SquidPortInt80
+        ToPort: !Ref SquidPortInt80
+        CidrIp: 10.0.0.0/8
+      - IpProtocol: tcp
+        FromPort: !Ref SquidPortInt443
+        ToPort: !Ref SquidPortInt443
+        CidrIp: 10.0.0.0/8
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        #SourceSecurityGroupId: !Ref BastionInstanceSecurityGroup
+        CidrIp: 10.0.0.0/8
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-NAT2Instance']]
+
+  NAT2ELBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Squid proxy farm - ELB security group
+      VpcId:
+        Fn::ImportValue:
+          !Sub "{{ stack_name }}-net-VPCCiapBrowsingID"
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: !Ref SquidPort
+        ToPort: !Ref SquidPort
+        CidrIp: 10.0.0.0/8 #TODO: try to confine if relevent
+      - IpProtocol: tcp
+        FromPort: !Ref SquidPortInt80
+        ToPort: !Ref SquidPortInt80
+        CidrIp: 10.0.0.0/8 #TODO: try to confine if relevent
+      - IpProtocol: tcp
+        FromPort: !Ref SquidPortInt443
+        ToPort: !Ref SquidPortInt443
+        CidrIp: 10.0.0.0/8 #TODO: try to confine if relevent
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        #SourceSecurityGroupId: !Ref BastionInstanceSecurityGroup
+        CidrIp: 10.0.0.0/8 #TODO: try to confine if relevent
+      Tags:
+      - Key: Name
+        Value: !Join ['-', [!Ref 'AWS::StackName', 'CIAP-NAT2-ELB']]
+
+  #TODO: check if needed for port SquidPortInt80 and SquidPortInt443
+  NAT2ELBSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      DestinationSecurityGroupId: !Ref NAT2InstanceSecurityGroup
+      FromPort: !Ref SquidPort
+      GroupId: !Ref NAT2ELBSecurityGroup
+      IpProtocol: tcp
+      ToPort: !Ref SquidPort
+
+
   VPNInstanceSecurityGroup:
     Condition: VPNInstanceCondition
     Type: AWS::EC2::SecurityGroup
@@ -404,14 +488,16 @@ Resources:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Admin-Bastion-ELB']]
 
-  ### VPC Project
+  ### VPC CiapBrowsing
 
   TPInstanceSecurityGroup:
     Condition: TPInstanceCondition
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Enables outbound internet access for the VPC via the upstream NAT instances
-      VpcId: !Ref VPCProjectID
+      VpcId:
+        Fn::ImportValue:
+          !Sub "{{ stack_name }}-net-VPCCiapBrowsingID"
       SecurityGroupEgress:
       - CidrIp: !Ref VPCAdminCIDR
         FromPort: '-1'
@@ -449,7 +535,8 @@ Resources:
       - IpProtocol: tcp
         FromPort: 22
         ToPort: 22
-        SourceSecurityGroupId: !Ref BastionInstanceSecurityGroup
+        #SourceSecurityGroupId: !Ref BastionInstanceSecurityGroup
+        CidrIp: 10.0.0.0/8
       Tags:
       - Key: Name
         Value: !Join ['-', [!Ref 'AWS::StackName', 'Project-TPInstance']]
@@ -467,6 +554,11 @@ Outputs:
     Description: NAT Instance Security Group ID
     Export:
       Name: !Sub ${AWS::StackName}-NATInstanceSecurityGroupID
+  NAT2InstanceSecurityGroupID:
+    Value: !Ref NAT2InstanceSecurityGroup
+    Description: NAT2 Instance Security Group ID
+    Export:
+      Name: !Sub ${AWS::StackName}-NAT2InstanceSecurityGroupID
   TPInstanceSecurityGroupID:
     Value: !Ref TPInstanceSecurityGroup
     Description: Transparent Proxy Instance Security Group ID
@@ -482,6 +574,11 @@ Outputs:
     Description: NAT ELB Security Group ID
     Export:
       Name: !Sub ${AWS::StackName}-NATELBSecurityGroupID
+  NAT2ELBSecurityGroupID:
+    Value: !Ref NAT2ELBSecurityGroup
+    Description: NAT2 ELB Security Group ID
+    Export:
+      Name: !Sub ${AWS::StackName}-NAT2ELBSecurityGroupID
   VPNInstanceSecurityGroupID:
     Value: !Ref VPNInstanceSecurityGroup
     Description: VPN Instance Security Group ID

--- a/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/launch.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/cloudformation-infra/tasks/launch.yaml
@@ -10,9 +10,12 @@
       - Effect: Allow
         Action: sts:AssumeRole
         Principal:
-          AWS: arn:aws:iam::{{ root_account['account_id'] }}:user/{{ root_account['iam_user'] }}
-          Service: ec2.amazonaws.com
-          Service: cloudformation.amazonaws.com
+          AWS:
+            - arn:aws:iam::{{ root_account['account_id'] }}:user/{{ root_account['iam_user'] }}
+            - arn:aws:iam::{{ root_account['account_id'] }}:user/factotum-bootstrap
+          Service:
+            - ec2.amazonaws.com
+            - cloudformation.amazonaws.com
   register: iam
 
 - name: Saving installer role ID

--- a/reference-architecture/aws-ansible/playbooks/roles/pre-install-check/tasks/main.yaml
+++ b/reference-architecture/aws-ansible/playbooks/roles/pre-install-check/tasks/main.yaml
@@ -1,11 +1,10 @@
 ---
 - name: Get current Ansible version on local host
   assert:
-    that: "ansible_version.full | version_compare('2.2', '>=')"
-    msg: "You need Ansible version 2.2.0+"
+    that: "ansible_version.full | version_compare('2.8', '>=')"
+    msg: "You need Ansible version 2.8.0+"
 
     #- name: Fail if region has less than 3 AZs
     #  assert:
     #    that: "vpc_subnet_azs | version_compare('i3', '>=')"
     #    msg: "You need Ansible version 2.2.0+"
-


### PR DESCRIPTION
Fixes issue #8 [VPC Peerings](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-peering.html) are replaced by [TransitGateway](https://aws.amazon.com/fr/transit-gateway/)

For new stacks only.


